### PR TITLE
start adapting for an hybrid pe pc implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 (https://img.shields.io/badge/gitter-join%20chat-brightgreen.svg)]
 (https://gitter.im/PrismarineJS/prismarine-chunk)
 
+A class to hold chunk data for Minecraft PC 1.8 and PE 0.14
+
 ## Usage
 
 ```js
@@ -70,6 +72,10 @@ Get the block sky light at `pos`
 
 Get the block biome id at `pos`
 
+#### Chunk.getBiomeColor(pos)
+
+Get the block biome color at `pos`. Does nothing for PC.
+
 #### Chunk.setBlockType(pos, id)
 
 Set the block type `id` at `pos`
@@ -89,6 +95,10 @@ Set the block sky `light` at `pos`
 #### Chunk.setBiome(pos, biome)
 
 Set the block `biome` id at `pos`
+
+#### Chunk.setBiomeColor(pos, biomeColor)
+
+Set the block `biomeColor` at `pos`. Does nothing for PC.
 
 #### Chunk.dump()
 

--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-var Chunk = require('./')("pe_0.14");
+var Chunk = require('./')("1.8");
 var Vec3 = require("vec3");
 
 var chunk=new Chunk();

--- a/example.js
+++ b/example.js
@@ -1,12 +1,12 @@
-var Chunk = require('./')("1.8");
+var Chunk = require('./')("pe_0.14");
 var Vec3 = require("vec3");
 
 var chunk=new Chunk();
 
-for (var x = 0; x < 16;x++) {
-  for (var z = 0; z < 16; z++) {
+for (var x = 0; x < Chunk.width;x++) {
+  for (var z = 0; z < Chunk.length; z++) {
     chunk.setBlockType(new Vec3(x, 50, z), 2);
-    for (var y = 0; y < 256; y++) {
+    for (var y = 0; y < Chunk.height; y++) {
       chunk.setSkyLight(new Vec3(x, y, z), 15);
     }
   }

--- a/example.js
+++ b/example.js
@@ -2,11 +2,10 @@ var Chunk = require('./')("pe_0.14");
 var Vec3 = require("vec3");
 
 var chunk=new Chunk();
-
-for (var x = 0; x < Chunk.width;x++) {
-  for (var z = 0; z < Chunk.length; z++) {
+for (var x = 0; x < Chunk.w;x++) {
+  for (var z = 0; z < Chunk.l; z++) {
     chunk.setBlockType(new Vec3(x, 50, z), 2);
-    for (var y = 0; y < Chunk.height; y++) {
+    for (var y = 0; y < Chunk.h; y++) {
       chunk.setSkyLight(new Vec3(x, y, z), 15);
     }
   }

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/chunk.js');
+module.exports = require('./dist/index.js');

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,16 @@
+var chunkImplementations={
+  "pc":{
+    "1.8":require("./pc/1.8/chunk")
+  },
+  "pe":{
+    "0.14":require("./pe/0.14/chunk")
+  }
+};
+
+module.exports = loader;
+
+function loader(mcVersion) {
+  var mcData = require('minecraft-data')(mcVersion);
+
+  return chunkImplementations[mcData.type][mcData.version.majorVersion](mcVersion);
+}

--- a/src/pc/1.8/chunk.js
+++ b/src/pc/1.8/chunk.js
@@ -36,6 +36,7 @@ var getBiomeCursor = function (pos) {
   return ((16 * 16 * 16) * 16 * 3) + (pos.z * 16) + pos.x;
 };
 
+
 class Chunk {
 
   constructor() {
@@ -152,4 +153,17 @@ class Chunk {
     this.data = data;
   }
 
+  static get height() {
+    return 256;
+  }
+
+  static get length() {
+    return 16;
+  }
+
+  static get width() {
+    return 16;
+  }
+
 }
+

--- a/src/pc/1.8/chunk.js
+++ b/src/pc/1.8/chunk.js
@@ -95,6 +95,18 @@ class Chunk {
       this.setBlockLight(pos, block.light);
   }
 
+  getBiomeColor(pos) {
+    return {
+      r: 0,
+      g: 0,
+      b: 0
+    }
+  }
+
+  setBiomeColor(pos, r, g, b) {
+
+  }
+
   getBlockType(pos) {
     var cursor = getBlockCursor(pos);
     return this.data.readUInt16LE(cursor) >> 4;

--- a/src/pc/1.8/chunk.js
+++ b/src/pc/1.8/chunk.js
@@ -74,7 +74,7 @@ class Chunk {
         }
       }
     }
-  };
+  }
 
   getBlock(pos) {
     var block = new Block(this.getBlockType(pos), this.getBiome(pos), this.getBlockData(pos));

--- a/src/pc/1.8/chunk.js
+++ b/src/pc/1.8/chunk.js
@@ -13,6 +13,7 @@ function loader(mcVersion) {
   Chunk.w=w;
   Chunk.l=l;
   Chunk.h=h;
+  Chunk.BUFFER_SIZE=BUFFER_SIZE;
   return Chunk;
 }
 

--- a/src/pc/1.8/chunk.js
+++ b/src/pc/1.8/chunk.js
@@ -1,4 +1,8 @@
-const BUFFER_SIZE = ((16 * 16 * 16) * 16 * 3) + 256;
+const w=16;
+const l=16;
+const h=256;
+
+const BUFFER_SIZE = (w * l * h * 3) + w*l;
 
 var { readUInt4LE, writeUInt4LE } = require('uint4');
 
@@ -6,6 +10,9 @@ module.exports = loader;
 
 function loader(mcVersion) {
   Block = require('prismarine-block')(mcVersion);
+  Chunk.w=w;
+  Chunk.l=l;
+  Chunk.h=h;
   return Chunk;
 }
 
@@ -17,7 +24,7 @@ var exists = function (val) {
 
 
 var getArrayPosition = function (pos) {
-  return pos.x+16*(pos.z+16*pos.y);
+  return pos.x+w*(pos.z+l*pos.y);
 };
 
 var getBlockCursor = function (pos) {
@@ -25,15 +32,15 @@ var getBlockCursor = function (pos) {
 };
 
 var getBlockLightCursor = function(pos) {
-    return getArrayPosition(pos) * 0.5 + 256*16*16*2;
+    return getArrayPosition(pos) * 0.5 + w * l * h*2;
 };
 
 var getSkyLightCursor = function(pos) {
-  return getArrayPosition(pos) * 0.5 + 256*16*8*5;
+  return getArrayPosition(pos) * 0.5 + w * l * h/2*5;
 };
 
 var getBiomeCursor = function (pos) {
-  return ((16 * 16 * 16) * 16 * 3) + (pos.z * 16) + pos.x;
+  return (w * l * h * 3) + (pos.z * w) + pos.x;
 };
 
 
@@ -45,13 +52,13 @@ class Chunk {
   }
 
   initialize(iniFunc) {
-    const skylight=256*16*8*5;
-    const light=256*16*16*2;
-    let biome=((16 * 16 * 16) * 16 * 3)-1;
+    const skylight=w * l * h/2*5;
+    const light=w * l * h*2;
+    let biome=(w * l * h * 3)-1;
     let n=0;
-    for(let y=0;y<256;y++) {
-      for(let z=0;z<16;z++) {
-        for(let x=0;x<16;x++,n++) {
+    for(let y=0;y<h;y++) {
+      for(let z=0;z<w;z++) {
+        for(let x=0;x<l;x++,n++) {
           if(y==0)
             biome++;
           const block=iniFunc(x,y,z,n);
@@ -152,18 +159,5 @@ class Chunk {
       throw(new Error(`Data buffer not correct size \(was ${data.length}, expected ${BUFFER_SIZE}\)`));
     this.data = data;
   }
-
-  static get height() {
-    return 256;
-  }
-
-  static get length() {
-    return 16;
-  }
-
-  static get width() {
-    return 16;
-  }
-
 }
 

--- a/src/pe/0.14/chunk.js
+++ b/src/pe/0.14/chunk.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const BLOCK_DATA_SIZE = 16 * 16 * 128;
+const REGULAR_DATA_SIZE = 16384;
+const SKYLIGHT_DATA_SIZE = 16384;
+const BLOCKLIGHT_DATA_SIZE = 16384;
+const ADDITIONAL_DATA_SIZE_DIRTY = 256;
+const ADDITIONAL_DATA_SIZE_COLOR = 1024;
+const BUFFER_SIZE = BLOCK_DATA_SIZE + REGULAR_DATA_SIZE + SKYLIGHT_DATA_SIZE + BLOCKLIGHT_DATA_SIZE + ADDITIONAL_DATA_SIZE_COLOR + ADDITIONAL_DATA_SIZE_DIRTY;
+
+const readUInt4LE = require('uint4').readUInt4LE;
+const writeUInt4LE = require('uint4').writeUInt4LE;
+
+module.exports = loader;
+
+function loader(mcVersion) {
+  Block = require('prismarine-block')(mcVersion);
+  return Chunk;
+}
+
+var Block;
+
+function exists(val) {
+  return val !== undefined;
+}
+
+
+class Chunk {
+  constructor() {
+    this.blocks = new Buffer(BLOCK_DATA_SIZE);
+    this.data = new Buffer(REGULAR_DATA_SIZE);
+    this.skyLight = new Buffer(SKYLIGHT_DATA_SIZE);
+    this.blockLight = new Buffer(BLOCKLIGHT_DATA_SIZE);
+    this.heightMap = new Buffer(ADDITIONAL_DATA_SIZE_DIRTY);
+    this.biomeColors = new Buffer(ADDITIONAL_DATA_SIZE_COLOR);
+
+    this.blocks.fill(0);
+    this.data.fill(0);
+    this.skyLight.fill(0);
+    this.blockLight.fill(0);
+    this.heightMap.fill(0);
+    this.biomeColors.fill(0);
+  }
+
+  getBlock(pos) {
+    var block = new Block(this.getBlockType(pos), this.getBiome(pos), this.getBlockData(pos));
+    block.light = this.getBlockLight(pos);
+    block.skyLight = this.getSkyLight(pos);
+    return block;
+  }
+
+  setBlock(pos, block) {
+    if (exists(block.type))
+      this.setBlockType(pos, block.type);
+    if (exists(block.metadata))
+      this.setBlockData(pos, block.metadata);
+    if (exists(block.biome))
+      this.setBiome(pos, block.biome.id);
+    if (exists(block.skyLight))
+      this.setSkyLight(pos, block.skyLight);
+    if (exists(block.light))
+      this.setBlockLight(pos, block.light);
+  }
+
+  getBlockType(pos) {
+    return this.blocks[pos.x + 16 * (pos.z + 16 * pos.y)] & 0xff;
+  }
+
+  setBlockType(pos, id) {
+    this.blocks[pos.x + 16 * (pos.z + 16 * pos.y)] = id;
+  }
+
+  getBlockData(pos) {
+    return readUInt4LE(this.data, (pos.x + 16 * (pos.z + 16 * pos.y)) * 0.5);
+  }
+
+  setBlockData(pos, data) {
+    writeUInt4LE(this.data, data, (pos.x + 16 * (pos.z + 16 * pos.y)) * 0.5);
+  }
+
+  getBlockLight(pos) {
+    return readUInt4LE(this.blockLight, (pos.x + 16 * (pos.z + 16 * pos.y)) * 0.5);
+  }
+
+  setBlockLight(pos, light) {
+    writeUInt4LE(this.blockLight, light, (pos.x + 16 * (pos.z + 16 * pos.y)) * 0.5);
+  }
+
+  getSkyLight(pos) {
+    return readUInt4LE(this.skyLight, (pos.x + 16 * (pos.z + 16 * pos.y)) * 0.5);
+  }
+
+  setSkyLight(pos, light) {
+    writeUInt4LE(this.skyLight, light, (pos.x + 16 * (pos.z + 16 * pos.y)) * 0.5);
+  }
+
+  getBiomeColor(pos) {
+    var color = this.biomeColors.readInt32BE(((pos.z << 4) + pos.x) * 4) & 0xFFFFFF;
+
+    return {
+      r: (color >> 16),
+      g: ((color >> 8) & 0xFF),
+      b: (color & 0xFF)
+    }
+  }
+
+  setBiomeColor(pos, r, g, b) {
+    this.biomeColors.writeInt32BE((this.biomeColors.readInt32BE(((pos.z << 4) + pos.x) * 4) & 0xFF000000) | ((r & 0xFF) << 16) | ((g & 0xFF) << 8) | (b & 0XFF), ((pos.z << 4) + pos.x) * 4);
+  }
+
+  getBiome(pos) {
+    return (this.biomeColors.readInt32BE(((pos.z << 4) + pos.x) * 4) & 0xFF000000) >> 24;
+  }
+
+  setBiome(pos, id) {
+    this.biomeColors.writeInt32BE((this.biomeColors.readInt32BE(((pos.z << 4) + pos.x) * 4) & 0xFFFFFF) | (id << 24), ((pos.z << 4) + pos.x) * 4);
+  }
+
+  setHeight(pos, value) {
+    this.heightMap[(pos.z << 4) + pos.x] = value;
+  }
+
+  getHeight(pos) {
+    return this.heightMap[(pos.z << 4) + pos.x];
+  }
+
+  load(data) {
+    var offset = 0;
+
+    this.blocks = data.slice(0, BLOCK_DATA_SIZE);
+    offset += BLOCK_DATA_SIZE;
+
+    this.data = data.slice(offset, REGULAR_DATA_SIZE + offset);
+    offset += REGULAR_DATA_SIZE;
+
+    this.skyLight = data.slice(offset, SKYLIGHT_DATA_SIZE + offset);
+    offset += SKYLIGHT_DATA_SIZE;
+
+    this.blockLight = data.slice(offset, BLOCKLIGHT_DATA_SIZE + offset);
+    offset += BLOCKLIGHT_DATA_SIZE;
+
+    this.heightMap = data.slice(offset, ADDITIONAL_DATA_SIZE_DIRTY + offset);
+    offset += ADDITIONAL_DATA_SIZE_DIRTY;
+
+    this.biomeColors = data.slice(offset, ADDITIONAL_DATA_SIZE_COLOR + offset);
+    offset += ADDITIONAL_DATA_SIZE_COLOR;
+
+    return offset;
+  }
+
+  dump() {
+    return Buffer.concat([
+      this.blocks,
+      this.data,
+      this.skyLight,
+      this.blockLight,
+      this.heightMap,
+      this.biomeColors
+    ], BUFFER_SIZE);
+  }
+
+
+  static get height() {
+    return 128;
+  }
+
+  static get length() {
+    return 16;
+  }
+
+  static get width() {
+    return 16;
+  }
+}

--- a/src/pe/0.14/chunk.js
+++ b/src/pe/0.14/chunk.js
@@ -21,6 +21,7 @@ function loader(mcVersion) {
   Chunk.w=w;
   Chunk.l=l;
   Chunk.h=h;
+  Chunk.BUFFER_SIZE=BUFFER_SIZE;
   return Chunk;
 }
 
@@ -62,9 +63,9 @@ var getBiomeCursor = function (pos) {
 
 class Chunk {
   constructor() {
-    this.buffer = new Buffer(BUFFER_SIZE);
+    this.data = new Buffer(BUFFER_SIZE);
 
-    this.buffer.fill(0);
+    this.data.fill(0);
   }
 
   getBlock(pos) {
@@ -88,39 +89,39 @@ class Chunk {
   }
 
   getBlockType(pos) {
-    return this.buffer.readUInt8(getBlockCursor(pos));
+    return this.data.readUInt8(getBlockCursor(pos));
   }
 
   setBlockType(pos, id) {
-    this.buffer.writeUInt8(id,getBlockCursor(pos));
+    this.data.writeUInt8(id,getBlockCursor(pos));
   }
 
   getBlockData(pos) {
-    return readUInt4LE(this.buffer, getBlockDataCursor(pos));
+    return readUInt4LE(this.data, getBlockDataCursor(pos));
   }
 
   setBlockData(pos, data) {
-    writeUInt4LE(this.buffer, data, getBlockDataCursor(pos));
+    writeUInt4LE(this.data, data, getBlockDataCursor(pos));
   }
 
   getBlockLight(pos) {
-    return readUInt4LE(this.buffer, getBlockLightCursor(pos));
+    return readUInt4LE(this.data, getBlockLightCursor(pos));
   }
 
   setBlockLight(pos, light) {
-    writeUInt4LE(this.buffer, light, getBlockLightCursor(pos));
+    writeUInt4LE(this.data, light, getBlockLightCursor(pos));
   }
 
   getSkyLight(pos) {
-    return readUInt4LE(this.buffer, getSkyLightCursor(pos));
+    return readUInt4LE(this.data, getSkyLightCursor(pos));
   }
 
   setSkyLight(pos, light) {
-    writeUInt4LE(this.buffer, light, getSkyLightCursor(pos));
+    writeUInt4LE(this.data, light, getSkyLightCursor(pos));
   }
 
   getBiomeColor(pos) {
-    var color = this.buffer.readInt32BE(getBiomeCursor(pos)) & 0xFFFFFF;
+    var color = this.data.readInt32BE(getBiomeCursor(pos)) & 0xFFFFFF;
 
     return {
       r: (color >> 16),
@@ -130,31 +131,35 @@ class Chunk {
   }
 
   setBiomeColor(pos, r, g, b) {
-    this.buffer.writeInt32BE((this.buffer.readInt32BE(getBiomeCursor(pos)) & 0xFF000000)
+    this.data.writeInt32BE((this.data.readInt32BE(getBiomeCursor(pos)) & 0xFF000000)
       | ((r & 0xFF) << 16) | ((g & 0xFF) << 8) | (b & 0XFF), getBiomeCursor(pos));
   }
 
   getBiome(pos) {
-    return (this.buffer.readInt32BE(getBiomeCursor(pos)) & 0xFF000000) >> 24;
+    return (this.data.readInt32BE(getBiomeCursor(pos)) & 0xFF000000) >> 24;
   }
 
   setBiome(pos, id) {
-    this.buffer.writeInt32BE((this.buffer.readInt32BE(getBiomeCursor(pos)) & 0xFFFFFF) | (id << 24), getBiomeCursor(pos));
+    this.data.writeInt32BE((this.data.readInt32BE(getBiomeCursor(pos)) & 0xFFFFFF) | (id << 24), getBiomeCursor(pos));
   }
 
   getHeight(pos) {
-    return this.buffer.readUInt8(getHeightMapCursor(pos,value));
+    return this.data.readUInt8(getHeightMapCursor(pos,value));
   }
 
   setHeight(pos, value) {
-    this.buffer.writeUInt8(value,getHeightMapCursor(pos));
+    this.data.writeUInt8(value,getHeightMapCursor(pos));
   }
 
   load(data) {
-    this.buffer=data;
+    if (!Buffer.isBuffer(data))
+      throw(new Error('Data must be a buffer'));
+    if (data.length != BUFFER_SIZE)
+      throw(new Error(`Data buffer not correct size \(was ${data.length}, expected ${BUFFER_SIZE}\)`));
+    this.data = data;
   }
 
   dump() {
-    return this.buffer;
+    return this.data;
   }
 }

--- a/src/pe/0.14/chunk.js
+++ b/src/pe/0.14/chunk.js
@@ -139,7 +139,7 @@ class Chunk {
   }
 
   setBiome(pos, id) {
-    this.buffer.writeInt32BE((this.buffer.readInt32BE(getBiomeCursor(pos)) & 0xFFFFFF) | (id << 24), ((pos.z << 4) + pos.x) * 4);
+    this.buffer.writeInt32BE((this.buffer.readInt32BE(getBiomeCursor(pos)) & 0xFFFFFF) | (id << 24), getBiomeCursor(pos));
   }
 
   getHeight(pos) {

--- a/src/pe/0.14/chunk.js
+++ b/src/pe/0.14/chunk.js
@@ -68,6 +68,18 @@ class Chunk {
     this.data.fill(0);
   }
 
+  initialize(iniFunc) {
+    const p=new Vec3(0,0,0);
+    for(p.y=0; p.y<h; p.y++) {
+      for(p.z=0; p.z<w; p.z++) {
+        for(p.x=0; p.x<l; p.x++) {
+          const block=iniFunc(p.x, p.y, p.z);
+          this.setBlock(pos,block);
+        }
+      }
+    }
+  }
+
   getBlock(pos) {
     var block = new Block(this.getBlockType(pos), this.getBiome(pos), this.getBlockData(pos));
     block.light = this.getBlockLight(pos);

--- a/src/pe/0.14/chunk.js
+++ b/src/pe/0.14/chunk.js
@@ -40,40 +40,31 @@ var getBlockCursor = function (pos) {
 };
 
 var getBlockDataCursor = function(pos) {
-  return getArrayPosition(pos) * 0.5;
+  return BLOCK_DATA_SIZE+getArrayPosition(pos) * 0.5;
 };
 
 var getBlockLightCursor = function(pos) {
-  return getArrayPosition(pos) * 0.5;
+  return BLOCK_DATA_SIZE+REGULAR_DATA_SIZE+getArrayPosition(pos) * 0.5;
 };
 
 var getSkyLightCursor = function(pos) {
-  return getArrayPosition(pos) * 0.5;
-};
-
-var getBiomeCursor = function (pos) {
-  return ((pos.z * w) + pos.x)*4;
+  return BLOCK_DATA_SIZE+REGULAR_DATA_SIZE+SKYLIGHT_DATA_SIZE+getArrayPosition(pos) * 0.5;
 };
 
 var getHeightMapCursor = function (pos) {
-  return (pos.z * w) + pos.x;
+  return BLOCK_DATA_SIZE+REGULAR_DATA_SIZE+SKYLIGHT_DATA_SIZE+BLOCKLIGHT_DATA_SIZE+(pos.z * w) + pos.x;
 };
+
+var getBiomeCursor = function (pos) {
+  return BLOCK_DATA_SIZE+REGULAR_DATA_SIZE+SKYLIGHT_DATA_SIZE+BLOCKLIGHT_DATA_SIZE+ADDITIONAL_DATA_SIZE_DIRTY+((pos.z * w) + pos.x)*4;
+};
+
 
 class Chunk {
   constructor() {
-    this.blocks = new Buffer(BLOCK_DATA_SIZE);
-    this.data = new Buffer(REGULAR_DATA_SIZE);
-    this.skyLight = new Buffer(SKYLIGHT_DATA_SIZE);
-    this.blockLight = new Buffer(BLOCKLIGHT_DATA_SIZE);
-    this.heightMap = new Buffer(ADDITIONAL_DATA_SIZE_DIRTY);
-    this.biomeColors = new Buffer(ADDITIONAL_DATA_SIZE_COLOR);
+    this.buffer = new Buffer(BUFFER_SIZE);
 
-    this.blocks.fill(0);
-    this.data.fill(0);
-    this.skyLight.fill(0);
-    this.blockLight.fill(0);
-    this.heightMap.fill(0);
-    this.biomeColors.fill(0);
+    this.buffer.fill(0);
   }
 
   getBlock(pos) {
@@ -97,39 +88,39 @@ class Chunk {
   }
 
   getBlockType(pos) {
-    return this.blocks.readUInt8(getBlockCursor(pos));
+    return this.buffer.readUInt8(getBlockCursor(pos));
   }
 
   setBlockType(pos, id) {
-    this.blocks.writeUInt8(id,getBlockCursor(pos));
+    this.buffer.writeUInt8(id,getBlockCursor(pos));
   }
 
   getBlockData(pos) {
-    return readUInt4LE(this.data, getBlockDataCursor(pos));
+    return readUInt4LE(this.buffer, getBlockDataCursor(pos));
   }
 
   setBlockData(pos, data) {
-    writeUInt4LE(this.data, data, getBlockDataCursor(pos));
+    writeUInt4LE(this.buffer, data, getBlockDataCursor(pos));
   }
 
   getBlockLight(pos) {
-    return readUInt4LE(this.blockLight, getBlockLightCursor(pos));
+    return readUInt4LE(this.buffer, getBlockLightCursor(pos));
   }
 
   setBlockLight(pos, light) {
-    writeUInt4LE(this.blockLight, light, getBlockLightCursor(pos));
+    writeUInt4LE(this.buffer, light, getBlockLightCursor(pos));
   }
 
   getSkyLight(pos) {
-    return readUInt4LE(this.skyLight, getSkyLightCursor(pos));
+    return readUInt4LE(this.buffer, getSkyLightCursor(pos));
   }
 
   setSkyLight(pos, light) {
-    writeUInt4LE(this.skyLight, light, getSkyLightCursor(pos));
+    writeUInt4LE(this.buffer, light, getSkyLightCursor(pos));
   }
 
   getBiomeColor(pos) {
-    var color = this.biomeColors.readInt32BE(getBiomeCursor(pos)) & 0xFFFFFF;
+    var color = this.buffer.readInt32BE(getBiomeCursor(pos)) & 0xFFFFFF;
 
     return {
       r: (color >> 16),
@@ -139,57 +130,31 @@ class Chunk {
   }
 
   setBiomeColor(pos, r, g, b) {
-    this.biomeColors.writeInt32BE((this.biomeColors.readInt32BE(getBiomeCursor(pos)) & 0xFF000000) | ((r & 0xFF) << 16) | ((g & 0xFF) << 8) | (b & 0XFF), ((pos.z << 4) + pos.x) * 4);
+    this.buffer.writeInt32BE((this.buffer.readInt32BE(getBiomeCursor(pos)) & 0xFF000000)
+      | ((r & 0xFF) << 16) | ((g & 0xFF) << 8) | (b & 0XFF), getBiomeCursor(pos));
   }
 
   getBiome(pos) {
-    return (this.biomeColors.readInt32BE(getBiomeCursor(pos)) & 0xFF000000) >> 24;
+    return (this.buffer.readInt32BE(getBiomeCursor(pos)) & 0xFF000000) >> 24;
   }
 
   setBiome(pos, id) {
-    this.biomeColors.writeInt32BE((this.biomeColors.readInt32BE(getBiomeCursor(pos)) & 0xFFFFFF) | (id << 24), ((pos.z << 4) + pos.x) * 4);
+    this.buffer.writeInt32BE((this.buffer.readInt32BE(getBiomeCursor(pos)) & 0xFFFFFF) | (id << 24), ((pos.z << 4) + pos.x) * 4);
   }
 
   getHeight(pos) {
-    return this.heightMap.readUInt8(getHeightMapCursor(pos,value));
+    return this.buffer.readUInt8(getHeightMapCursor(pos,value));
   }
 
   setHeight(pos, value) {
-    this.heightMap.writeUInt8(value,getHeightMapCursor(pos));
+    this.buffer.writeUInt8(value,getHeightMapCursor(pos));
   }
 
   load(data) {
-    var offset = 0;
-
-    this.blocks = data.slice(0, BLOCK_DATA_SIZE);
-    offset += BLOCK_DATA_SIZE;
-
-    this.data = data.slice(offset, REGULAR_DATA_SIZE + offset);
-    offset += REGULAR_DATA_SIZE;
-
-    this.skyLight = data.slice(offset, SKYLIGHT_DATA_SIZE + offset);
-    offset += SKYLIGHT_DATA_SIZE;
-
-    this.blockLight = data.slice(offset, BLOCKLIGHT_DATA_SIZE + offset);
-    offset += BLOCKLIGHT_DATA_SIZE;
-
-    this.heightMap = data.slice(offset, ADDITIONAL_DATA_SIZE_DIRTY + offset);
-    offset += ADDITIONAL_DATA_SIZE_DIRTY;
-
-    this.biomeColors = data.slice(offset, ADDITIONAL_DATA_SIZE_COLOR + offset);
-    offset += ADDITIONAL_DATA_SIZE_COLOR;
-
-    return offset;
+    this.buffer=data;
   }
 
   dump() {
-    return Buffer.concat([
-      this.blocks,
-      this.data,
-      this.skyLight,
-      this.blockLight,
-      this.heightMap,
-      this.biomeColors
-    ], BUFFER_SIZE);
+    return this.buffer;
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,76 +1,76 @@
 var assert = require('assert');
-var Vec3= require("vec3");
+var Vec3 = require("vec3");
 
-var Chunk = require('../index.js')("1.8");
+const versions=['pe_0.14','1.8'];
+versions.forEach(function(version) {
+  var Chunk = require('../index.js')(version);
+  var Block = require('prismarine-block')(version);
+  describe('chunk '+version, function () {
+    it('should default to having all blocks be air', function () {
+      var chunk = new Chunk();
 
-var Block = require('prismarine-block')("1.8");
-
-describe('chunk', function() {
-    it('should default to having all blocks be air', function() {
-        var chunk = new Chunk();
-
-        assert.equal(0, chunk.getBlock(new Vec3(0, 0, 0)).type);
-        assert.equal(0, chunk.getBlock(new Vec3(15, Chunk.h-1, 15)).type);
+      assert.equal(0, chunk.getBlock(new Vec3(0, 0, 0)).type);
+      assert.equal(0, chunk.getBlock(new Vec3(15, Chunk.h - 1, 15)).type);
     });
-    it('should set a block at the given position', function() {
-        var chunk = new Chunk();
+    it('should set a block at the given position', function () {
+      var chunk = new Chunk();
 
-        chunk.setBlock(new Vec3(0, 0, 0), new Block(5,0,2)); // Birch planks, if you're wondering
-        assert.equal(5, chunk.getBlock(new Vec3(0, 0, 0)).type);
-        assert.equal(2, chunk.getBlock(new Vec3(0, 0, 0)).metadata);
+      chunk.setBlock(new Vec3(0, 0, 0), new Block(5, 0, 2)); // Birch planks, if you're wondering
+      assert.equal(5, chunk.getBlock(new Vec3(0, 0, 0)).type);
+      assert.equal(2, chunk.getBlock(new Vec3(0, 0, 0)).metadata);
 
-        chunk.setBlock(new Vec3(0, 1, 0),new Block(42,0,0)); // Iron block
-        assert.equal(42, chunk.getBlock(new Vec3(0, 1, 0)).type);
-        assert.equal(0,  chunk.getBlock(new Vec3(0, 1, 0)).metadata);
+      chunk.setBlock(new Vec3(0, 1, 0), new Block(42, 0, 0)); // Iron block
+      assert.equal(42, chunk.getBlock(new Vec3(0, 1, 0)).type);
+      assert.equal(0, chunk.getBlock(new Vec3(0, 1, 0)).metadata);
 
-        chunk.setBlock(new Vec3(1, 0, 0), new Block(35,0,1)); // Orange wool
-        assert.equal(35, chunk.getBlock(new Vec3(1, 0, 0)).type);
-        assert.equal(1,  chunk.getBlock(new Vec3(1, 0, 0)).metadata);
+      chunk.setBlock(new Vec3(1, 0, 0), new Block(35, 0, 1)); // Orange wool
+      assert.equal(35, chunk.getBlock(new Vec3(1, 0, 0)).type);
+      assert.equal(1, chunk.getBlock(new Vec3(1, 0, 0)).metadata);
     });
-    it('should overwrite blocks in place', function() {
-        var chunk = new Chunk();
+    it('should overwrite blocks in place', function () {
+      var chunk = new Chunk();
 
-        chunk.setBlock(new Vec3(0, 1, 0), new Block(42,0, 0)); // Iron block
-        chunk.setBlock(new Vec3(0, 1, 0), new Block(41,0,0)); // Gold block
-        assert.equal(41, chunk.getBlock(new Vec3(0, 1, 0)).type);
-        assert.equal(0,  chunk.getBlock(new Vec3(0, 1, 0)).metadata);
+      chunk.setBlock(new Vec3(0, 1, 0), new Block(42, 0, 0)); // Iron block
+      chunk.setBlock(new Vec3(0, 1, 0), new Block(41, 0, 0)); // Gold block
+      assert.equal(41, chunk.getBlock(new Vec3(0, 1, 0)).type);
+      assert.equal(0, chunk.getBlock(new Vec3(0, 1, 0)).metadata);
 
-        chunk.setBlock(new Vec3(5, 5, 5), new Block(35,0, 1));  // Orange wool
-        chunk.setBlock(new Vec3(5, 5, 5), new Block(35,0, 14)); // Red wool
-        assert.equal(35, chunk.getBlock(new Vec3(5, 5, 5)).type);
-        assert.equal(14, chunk.getBlock(new Vec3(5, 5, 5)).metadata);
+      chunk.setBlock(new Vec3(5, 5, 5), new Block(35, 0, 1));  // Orange wool
+      chunk.setBlock(new Vec3(5, 5, 5), new Block(35, 0, 14)); // Red wool
+      assert.equal(35, chunk.getBlock(new Vec3(5, 5, 5)).type);
+      assert.equal(14, chunk.getBlock(new Vec3(5, 5, 5)).metadata);
     });
-    it('should return the internal buffer when calling #dump()', function() {
-        var chunk = new Chunk();
+    it('should return the internal buffer when calling #dump()', function () {
+      var chunk = new Chunk();
 
-        chunk.setBlock(new Vec3(0, 0, 0), new Block(5,0, 2)); // Birch planks
+      chunk.setBlock(new Vec3(0, 0, 0), new Block(5, 0, 2)); // Birch planks
 
-        var buffer = chunk.dump();
-        assert.equal(0x52, buffer[0]);
+      var buffer = chunk.dump();
+      assert.equal(version == "1.8" ? 0x52 : 0x5, buffer[0]);
     });
-    it('should replace the inner buffer when calling #load()', function() {
-        var chunk = new Chunk();
+    it('should replace the inner buffer when calling #load()', function () {
+      var chunk = new Chunk();
 
-        var buffer = new Buffer(196864);
-        buffer[0] = 0x52;
+      var buffer = new Buffer(Chunk.BUFFER_SIZE);
+      buffer[0] = version == "1.8" ? 0x52 : 0x5;
 
-        chunk.load(buffer);
+      chunk.load(buffer);
 
-        assert.equal(5, chunk.getBlockType(new Vec3(0, 0, 0)));
-        assert.equal(2, chunk.getBlockData(new Vec3(0, 0, 0)));
+      assert.equal(5, chunk.getBlockType(new Vec3(0, 0, 0)));
     });
-    it('should fail savely when load is given bad input', function() {
-        var chunk = new Chunk();
+    it('should fail savely when load is given bad input', function () {
+      var chunk = new Chunk();
 
-        var tooShort = new Buffer(3);
-        var notABuffer = [];
+      var tooShort = new Buffer(3);
+      var notABuffer = [];
 
-        assert.throws(function() {
-            chunk.load(tooShort);
-        });
+      assert.throws(function () {
+        chunk.load(tooShort);
+      });
 
-        assert.throws(function() {
-            chunk.load(notABuffer);
-        });
+      assert.throws(function () {
+        chunk.load(notABuffer);
+      });
     });
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ describe('chunk', function() {
         var chunk = new Chunk();
 
         assert.equal(0, chunk.getBlock(new Vec3(0, 0, 0)).type);
-        assert.equal(0, chunk.getBlock(new Vec3(15, Chunk.height-1, 15)).type);
+        assert.equal(0, chunk.getBlock(new Vec3(15, Chunk.h-1, 15)).type);
     });
     it('should set a block at the given position', function() {
         var chunk = new Chunk();

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ describe('chunk', function() {
         var chunk = new Chunk();
 
         assert.equal(0, chunk.getBlock(new Vec3(0, 0, 0)).type);
-        assert.equal(0, chunk.getBlock(new Vec3(15, 255, 15)).type);
+        assert.equal(0, chunk.getBlock(new Vec3(15, Chunk.height-1, 15)).type);
     });
     it('should set a block at the given position', function() {
         var chunk = new Chunk();


### PR DESCRIPTION
* [x] example works
* [x] use height, width and length constants at more places
* [x] make pe implementation use only one buffer for consistency (almost there)
* [x] add setBiomeColor to pc api (make it do nothing)
* [x] make tests run on both pe and pc automatically
* [x] implement initialize for pe (can be a simple loop to begin with)
* [x] set a decent color by default in pe (for generator meant for pc) : no let's not do that, it would be really sub-optimal, we can think of the best way to integrate pc generators when it comes to that