### PR TITLE
Optimizing chunk-1.9.js file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 dist/
-benchmark/chunk-1.9.csv
+benchmarks/results/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
+benchmark/chunk-1.9.csv
 

--- a/benchmarks/chunk-1.9.js
+++ b/benchmarks/chunk-1.9.js
@@ -8,15 +8,16 @@ const blockCounts = Object.keys(blocks).length
 const Chunk = chunk('1.12.1')
 
 const blockCache = {}
+function initBlock(x,y,z) {
+  const type = (x + y + z) % blockCounts
+  return blockCache[type] || (blockCache[type] = new Block(type, 0, 0))
+}
 
 function benchmark() {
   for (let i = 0; i<1000; i++) {
     const c = new Chunk()
 
-    c.initialize((x,y,z) => {
-      const type = (x + y + z) % blockCounts
-      return blockCache[type] || (blockCache[type] = new Block(type, 0, 0))
-    })
+    c.initialize(initBlock)
     const block = c.getBlock(new Vec3(0, 0, 0))
     c.setBlock(new Vec3(0, 0, 0), block)
 

--- a/benchmarks/chunk-1.9.js
+++ b/benchmarks/chunk-1.9.js
@@ -1,0 +1,29 @@
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+const blocks = require("minecraft-data")('1.12.1').blocks;
+const chunk = require('../src/pc/1.9/chunk.js')
+const Block = require('prismarine-block')('1.12.1');
+const Vec3 = require('vec3');
+
+const blockCounts = Object.keys(blocks).length
+const Chunk = chunk('1.12.1')
+
+const blockCache = {}
+
+function benchmark() {
+  for (let i = 0; i<100; i++) {
+    const c = new Chunk()
+
+    c.initialize((x,y,z) => {
+      const type = (x + y + z) % blockCounts
+      return blockCache[type] || (blockCache[type] = new Block(type, 0, 0))
+    })
+    const block = c.getBlock(new Vec3(0, 0, 0))
+    c.setBlock(new Vec3(0, 0, 0), block)
+
+    const buffer = c.dump()
+    const c2 = new Chunk()
+    c2.load(buffer, 0, 0)
+  }
+}
+
+module.exports = benchmark

--- a/benchmarks/chunk-1.9.js
+++ b/benchmarks/chunk-1.9.js
@@ -10,7 +10,7 @@ const Chunk = chunk('1.12.1')
 const blockCache = {}
 
 function benchmark() {
-  for (let i = 0; i<100; i++) {
+  for (let i = 0; i<1000; i++) {
     const c = new Chunk()
 
     c.initialize((x,y,z) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bit-twiddle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
-      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -392,8 +392,7 @@
     "vec3": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/vec3/-/vec3-0.1.3.tgz",
-      "integrity": "sha1-9ZUuEFN9nW64VLirfO8BsvwU5a8=",
-      "dev": true
+      "integrity": "sha1-9ZUuEFN9nW64VLirfO8BsvwU5a8="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,410 @@
+{
+  "name": "prismarine-chunk",
+  "version": "1.7.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bit-twiddle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+    },
+    "minecraft-data": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.20.0.tgz",
+      "integrity": "sha512-/hVeAWig7BobisuzCdX3zX38q11EChdt1nQYHdldcyJXvaVVYF/2IALn/2B+C6Guz+CFM/F7psEkmdcf4gp5yA==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "prismarine-biome": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prismarine-biome/-/prismarine-biome-1.0.1.tgz",
+      "integrity": "sha1-AuTglRwfEVCLXKy7AU67dt3dsE0="
+    },
+    "prismarine-block": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prismarine-block/-/prismarine-block-1.0.1.tgz",
+      "integrity": "sha1-W16mFCa0zWvDkv5a2CcPv39WdeI=",
+      "requires": {
+        "prismarine-biome": "1.0.1"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "protodef": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/protodef/-/protodef-1.5.1.tgz",
+      "integrity": "sha1-MnGo1xH/R67U1/xyNScvAlfnlGc=",
+      "requires": {
+        "lodash.get": "4.4.2",
+        "lodash.reduce": "4.6.0",
+        "protodef-validator": "1.1.7",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "protodef-validator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/protodef-validator/-/protodef-validator-1.1.7.tgz",
+      "integrity": "sha1-uICAJKf3KtYr3uS5CUhjksmHjbY=",
+      "requires": {
+        "ajv": "4.11.8"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "uint4": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/uint4/-/uint4-0.1.2.tgz",
+      "integrity": "sha1-UMWuBLhdKBKPLfPMDsxNQavC9oE="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "vec3": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/vec3/-/vec3-0.1.3.tgz",
+      "integrity": "sha1-9ZUuEFN9nW64VLirfO8BsvwU5a8=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "minecraft-data": "^2.8.0"
   },
   "dependencies": {
-    "bit-twiddle": "^1.0.2",
     "prismarine-block": "^1.0.0",
     "protodef": "^1.3.1",
     "uint4": "^0.1.2"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "benchmark": "bench-csv ./benchmarks/chunk-1.9.js -o ./benchmarks/chunk-1.9.csv --repeat 10"
+    "benchmark": "bench-csv ./benchmarks/chunk-1.9.js -o ./benchmarks/results/chunk-1.9.csv --repeat 10 --warmups=1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "benchmark": "bench-csv ./benchmarks/chunk-1.9.js -o ./benchmarks/results/chunk-1.9.csv --repeat 10 --warmups=1"
+    "benchmark": "bench-csv ./benchmarks/chunk-1.9.js -o ./benchmarks/results/chunk-1.9.csv"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/PrismarineJS/prismarine-chunk",
   "devDependencies": {
-    "mocha": "^3.2.0",
-    "vec3": "~0.1.3",
-    "minecraft-data": "^2.8.0"
+    "minecraft-data": "^2.8.0",
+    "mocha": "^3.2.0"
   },
   "dependencies": {
     "prismarine-block": "^1.0.0",
     "protodef": "^1.3.1",
-    "uint4": "^0.1.2"
+    "uint4": "^0.1.2",
+    "vec3": "^0.1.3"
   },
   "engines": {
     "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "minecraft-data": "^2.8.0"
   },
   "dependencies": {
+    "bit-twiddle": "^1.0.2",
     "prismarine-block": "^1.0.0",
     "protodef": "^1.3.1",
     "uint4": "^0.1.2"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A class to hold chunk data for prismarine",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "benchmark": "bench-csv ./benchmarks/chunk-1.9.js -o ./benchmarks/chunk-1.9.csv --repeat 10"
   },
   "repository": {
     "type": "git",

--- a/src/pc/1.9/chunk.js
+++ b/src/pc/1.9/chunk.js
@@ -323,20 +323,23 @@ class Chunk {
       resultantBuffer.writeUInt32BE(newdata>>>0, startbyte);
     }
 
-    //now, we jumble: (and we're sure to drop those extra 4 bytes!)
+    // drop the last 4 bytes, and then reverse all bits in the buffer in 64 bit chunks
+    return this.reverseAllBits64InBuffer(resultantBuffer.slice(0, resultantBuffer.length - 4));
+  }
+
+  reverseAllBits64InBuffer(buffer) {
+    // Reverses all bits in the buffer in 64 bit chunks
     //Pretty sure this can be done by using a smaller buffer in the loop above that flushes whenever more than 8 bytes are pushed into it
-    for (let l = 0; l < resultantBuffer.length - 4; l += 8) {
+    for (let l = 0; l < buffer.length; l += 8) {
       //Load the long
-      let longleftjumbled = resultantBuffer.readUInt32BE(l);
-      let longrightjumbled = resultantBuffer.readUInt32BE(l + 4);
+      let longleftjumbled = buffer.readUInt32BE(l);
+      let longrightjumbled = buffer.readUInt32BE(l + 4);
       //Write in reverse order -- flip bits by using little endian.
-      resultantBuffer.writeInt32BE(reverseBits32(longrightjumbled), l);
-      resultantBuffer.writeInt32BE(reverseBits32(longleftjumbled), l + 4);
+      buffer.writeInt32BE(reverseBits32(longrightjumbled), l);
+      buffer.writeInt32BE(reverseBits32(longleftjumbled), l + 4);
     }
 
-    // drop the last 4 bytes
-    // slicing reuses the same memory
-    return resultantBuffer.slice(0, resultantBuffer.length - 4);
+    return buffer
   }
 
   reverseBits(data, n) {

--- a/src/reverse-bits.js
+++ b/src/reverse-bits.js
@@ -1,0 +1,37 @@
+// Taken from bit-twiddle library
+const REVERSE_TABLE = new Array(256);
+
+(function(tab) {
+  for(let i=0; i<256; ++i) {
+    let v = i, r = i, s = 7;
+    for (v >>>= 1; v; v >>>= 1) {
+      r <<= 1;
+      r |= v & 1;
+      --s;
+    }
+    tab[i] = (r << s) & 0xff;
+  }
+})(REVERSE_TABLE);
+
+module.exports.reverseBits32 = (v) =>
+  (REVERSE_TABLE[ v         & 0xff] << 24) |
+  (REVERSE_TABLE[(v >>> 8)  & 0xff] << 16) |
+  (REVERSE_TABLE[(v >>> 16) & 0xff] << 8)  |
+  REVERSE_TABLE[(v >>> 24) & 0xff];
+
+module.exports.reverseBits16 = (v) =>
+  (REVERSE_TABLE[ v         & 0xff] << 8) |
+  REVERSE_TABLE[(v >>> 8)  & 0xff];
+
+module.exports.reverseBits = (data, n) => {
+  let datau = data >>> 0;//Coerce unsigned.
+  let storage = 0;
+  for (let i = 0; i < n; i++) {
+    storage = storage | (datau & 1);
+    if (i != n - 1) {
+      storage = storage << 1;
+      datau = datau >>> 1;
+    }
+  }
+  return storage;
+};


### PR DESCRIPTION
Methodology:

1. Created a chunk-1.9.js benchmark module in /benchmarks. It initializes a chunk, sets a block, dumps the chunk, then loads it x 1000.
2. ran `npm run benchmark -- --watch --inspect` and then pointed the remote debugger tools from V8 at it.
3. Ran the CPU profiler for a while so that it could identify functions that were not being optimized, or that were generally hot spots.
4. Tweaked the code and reran the profiler until the timings in the /benchmarks/results/chunk-1.9.csv file started dropping. (running npm test of course)
5. Go back to 3

Periodically I'd run flying-squid with the chunk module npm linked just to see what kind of effect the tweaks had on the game.

The end product here is that the benchmark went from taking around 14 seconds on my laptop to running in just over  5s on average. There are still some more changes that'll probably take this down even further.

Running off of current master:

    "pid","timestamp","duration","memory"
    "6978","2017-09-03T19:02:35.285Z","14673","96654882"
    "7025","2017-09-03T19:02:51.346Z","14183","100174085"
    "7025","2017-09-03T19:03:06.420Z","14049","67782648"
    "7025","2017-09-03T19:03:21.706Z","14262","67234012"
    "7025","2017-09-03T19:03:36.932Z","14199","63658020"

Running off this branch:

    "pid","timestamp","duration","memory"
    "7652","2017-09-03T19:06:19.193Z","5372","9406876"
    "7686","2017-09-03T19:06:26.432Z","5460","9619313"
    "7686","2017-09-03T19:06:32.795Z","5330","14566624"
    "7686","2017-09-03T19:06:39.073Z","5250","0"
    "7686","2017-09-03T19:06:45.394Z","5294","6949280"
    "7686","2017-09-03T19:06:52.003Z","5579","0"

I'd love to continue this kind of work on other parts of the flying-squid project.

Let me know what you think.