### PR TITLE
add 3 bytes to the unjumbledBuffer in 1.9

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: 6
+    version: 10


### PR DESCRIPTION
so that we can read 4 bytes from the buffer even if up to 3 bytes are missing

fix #40