### PR TITLE
Switch to ProtoDefc

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "mocha",
     "benchmark": "bench-csv ./benchmarks/chunk-1.9.js -o ./benchmarks/results/chunk-1.9.csv",
-    "lint":"standard",
-    "pretest":"npm run lint"
+    "lint": "standard",
+    "pretest": "npm run lint"
   },
   "repository": {
     "type": "git",
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "prismarine-block": "^1.0.0",
-    "protodef": "^1.3.1",
     "uint4": "^0.1.2",
     "vec3": "^0.1.3"
   },


### PR DESCRIPTION
This is an experimental pull request for prismarine-chunk that switches from ProtoDef to ProtoDef*c*. This pull request is not close to ready, it requires many things to be done first, most of which are documented here: https://github.com/ProtoDef-io/node-protodefc/pull/7

As well, this means that this repository will only work for Node version >= 8.3 (which I have been assured is not an issue)

So, for some numbers:
- ProtoDefc
  - 7079/duration
- ProtoDef
  - 6273/duration

Yes. Your eyes are not deceiving you. ProtoDefc is slower, and I have tested it over 20 times. However, it is easily explained: ProtoDefc JIT compiles the protocol during the program execution. This certainly has a 1000+ms overhead. I predict that if this overhead is removed and ProtoDefc is 'warmed up', it will perform noticeably better on softwares like flying-squid. What's left:

- [ ] Actually make sure it generates a real world and it's not just doing useless computation (yes, I haven't even tested this yet)
- [ ] Test it against flying-squid and see if there is a noticeable improvement
- [ ] Benchmark them fairly, i.e.: loading the compiled JS from disk (perhaps consider just bundling this JS w/ a prismarine-chunk release and add that functionality to node-protodefc)
- [ ] Have node-protodefc ready for release
