### PR TITLE
Fix expected size in data buffer not correct error

### DIFF
--- a/src/pc/1.8/chunk.js
+++ b/src/pc/1.8/chunk.js
@@ -179,6 +179,6 @@ class Chunk {
     }
     data.copy(this.biome, w * l * sectionCount * chunkCount * 3)
 
-    if (data.length !== SECTION_SIZE * chunkCount + w * l) { throw (new Error(`Data buffer not correct size (was ${data.length}, expected ${BUFFER_SIZE})`)) }
+    if (data.length !== SECTION_SIZE * chunkCount + w * l) { throw (new Error(`Data buffer not correct size (was ${data.length}, expected ${SECTION_SIZE * chunkCount + w * l})`)) }
   }
 }

--- a/src/pc/1.8/chunk.js
+++ b/src/pc/1.8/chunk.js
@@ -162,7 +162,6 @@ class Chunk {
     if (!Buffer.isBuffer(data)) { throw (new Error('Data must be a buffer')) }
 
     const SECTION_SIZE = Section.sectionSize(skyLightSent)
-    const BUFFER_SIZE = SECTION_SIZE * sectionCount + BIOME_SIZE
 
     const { chunkIncluded, chunkCount } = parseBitMap(bitMap)
     let offset = 0


### PR DESCRIPTION
While trying to use this library I hit a contradictory error message:

```
    if (data.length !== SECTION_SIZE * chunkCount + w * l) { throw (new Error(`Data buffer not correct size (was ${data.length}, expected ${BUFFER_SIZE})`)) }
                                                             ^

Error: Data buffer not correct size (was 196864, expected 196864)
```

turns out the error message was wrong, as seen from the code excerpt, this pull request fixes it by changing BUFFER_SIZE  to SECTION_SIZE * chunkCount + w * l