### PR TITLE
fix dumping for noSkylight chunks on 1.9

### DIFF
--- a/src/pc/1.9/chunk.js
+++ b/src/pc/1.9/chunk.js
@@ -119,6 +119,7 @@ const getBiomeCursor = (pos) => X3_CHUNK_VOLUME + (pos.z * w) + pos.x
 class Chunk {
   constructor () {
     this.data = Buffer.alloc(BUFFER_SIZE)
+    this.hasSkylight = true
   }
 
   initialize (iniFunc) {
@@ -241,19 +242,33 @@ class Chunk {
 
     let currentDataIndex = 0
     let currentBlockLightIndex = CHUNK_VOLUME << 1
-    let currentSkyLightIndex = currentBlockLightIndex + (CHUNK_VOLUME >>> 1)
-    const biomeStart = currentSkyLightIndex + (CHUNK_VOLUME >>> 1)
+    let currentSkyLightIndex
+    if(this.hasSkylight) {
+      currentSkyLightIndex = currentBlockLightIndex + (CHUNK_VOLUME >>> 1)
+     } else {
+       currentSkyLightIndex = currentBlockLightIndex
+     }
+     const biomeStart = currentSkyLightIndex + (CHUNK_VOLUME >>> 1)
 
     const outputBuffers = []
 
     for (let y = 0; y < 16; y++) {
-      outputBuffers.push(Chunk.packingProtocol.createPacketBuffer('section', {
-        bitsPerBlock: 13,
-        palette: [],
-        dataArray: this.packBlockData(this.data.slice(currentDataIndex, currentDataIndex + twiceChunkBlocks), 13),
-        blockLight: this.data.slice(currentBlockLightIndex, currentBlockLightIndex + halfChunkBlocks),
-        skyLight: this.data.slice(currentSkyLightIndex, currentSkyLightIndex + halfChunkBlocks)
-      }))
+      if(this.hasSkylight) {
+        outputBuffers.push(Chunk.packingProtocol.createPacketBuffer('section', {
+          bitsPerBlock: 13,
+          palette: [],
+          dataArray: this.packBlockData(this.data.slice(currentDataIndex, currentDataIndex + twiceChunkBlocks), 13),
+          blockLight: this.data.slice(currentBlockLightIndex, currentBlockLightIndex + halfChunkBlocks),
+          skyLight: this.data.slice(currentSkyLightIndex, currentSkyLightIndex + halfChunkBlocks)
+        }))
+      } else {
+        outputBuffers.push(Chunk.packingProtocol.createPacketBuffer('sectionNoSkylight', {
+          bitsPerBlock: 13,
+          palette: [],
+          dataArray: this.packBlockData(this.data.slice(currentDataIndex, currentDataIndex + twiceChunkBlocks), 13),
+          blockLight: this.data.slice(currentBlockLightIndex, currentBlockLightIndex + halfChunkBlocks),
+        }))
+      }
 
       currentDataIndex += twiceChunkBlocks
       currentBlockLightIndex += halfChunkBlocks
@@ -318,6 +333,7 @@ class Chunk {
     if (!Buffer.isBuffer(unpackeddata)) { throw (new Error('Data must be a buffer')) }
     if (unpackeddata.length !== BUFFER_SIZE) { throw (new Error('Data buffer not correct size (was ' + unpackeddata.length + ', expected ' + BUFFER_SIZE + ')')) }
     this.data = unpackeddata
+    this.hasSkylight = skyLightSent
   }
 
   unpackChunkData (chunk, bitMap, skyLightSent) {

--- a/src/pc/1.9/chunk.js
+++ b/src/pc/1.9/chunk.js
@@ -243,17 +243,17 @@ class Chunk {
     let currentDataIndex = 0
     let currentBlockLightIndex = CHUNK_VOLUME << 1
     let currentSkyLightIndex
-    if(this.hasSkylight) {
+    if (this.hasSkylight) {
       currentSkyLightIndex = currentBlockLightIndex + (CHUNK_VOLUME >>> 1)
-     } else {
-       currentSkyLightIndex = currentBlockLightIndex
-     }
-     const biomeStart = currentSkyLightIndex + (CHUNK_VOLUME >>> 1)
+    } else {
+      currentSkyLightIndex = currentBlockLightIndex
+    }
+    const biomeStart = currentSkyLightIndex + (CHUNK_VOLUME >>> 1)
 
     const outputBuffers = []
 
     for (let y = 0; y < 16; y++) {
-      if(this.hasSkylight) {
+      if (this.hasSkylight) {
         outputBuffers.push(Chunk.packingProtocol.createPacketBuffer('section', {
           bitsPerBlock: 13,
           palette: [],
@@ -266,7 +266,7 @@ class Chunk {
           bitsPerBlock: 13,
           palette: [],
           dataArray: this.packBlockData(this.data.slice(currentDataIndex, currentDataIndex + twiceChunkBlocks), 13),
-          blockLight: this.data.slice(currentBlockLightIndex, currentBlockLightIndex + halfChunkBlocks),
+          blockLight: this.data.slice(currentBlockLightIndex, currentBlockLightIndex + halfChunkBlocks)
         }))
       }
 


### PR DESCRIPTION
the 1.9 chunk implementation correctly differentiates between noSkylight chunks (like the nether and the end) and skylight chunks (the overworld) when loading chunk data, but it just assumes all chunks are skylight chunks when dumping. this pull request saves the type of the chunk when loading and dumps it correctly based on the saved type. (its possible the 1.13 implementation might have the same problem, but im less familiar with it)