### PR TITLE
Add get/set for stateId to 1.8 and 1.9 versions

### DIFF
--- a/src/pc/1.8/chunk.js
+++ b/src/pc/1.8/chunk.js
@@ -97,6 +97,10 @@ class Chunk {
     return this.sections[pos.y >> 4]
   }
 
+  getBlockStateId (pos) {
+    return this._getSection(pos).getBlockStateId(posInSection(pos))
+  }
+
   getBlockType (pos) {
     return this._getSection(pos).getBlockType(posInSection(pos))
   }
@@ -116,6 +120,10 @@ class Chunk {
   getBiome (pos) {
     const cursor = getBiomeCursor(pos)
     return this.biome.readUInt8(cursor)
+  }
+
+  setBlockStateId (pos, stateId) {
+    return this._getSection(pos).setBlockStateId(posInSection(pos), stateId)
   }
 
   setBlockType (pos, id) {

--- a/src/pc/1.8/section.js
+++ b/src/pc/1.8/section.js
@@ -61,6 +61,11 @@ class Section {
 
   }
 
+  getBlockStateId (pos) {
+    const cursor = getBlockCursor(pos)
+    return this.data.readUInt16LE(cursor)
+  }
+
   getBlockType (pos) {
     const cursor = getBlockCursor(pos)
     return this.data.readUInt16LE(cursor) >> 4
@@ -79,6 +84,11 @@ class Section {
   getSkyLight (pos) {
     const cursor = getSkyLightCursor(pos)
     return readUInt4LE(this.data, cursor)
+  }
+
+  setBlockStateId (pos, stateId) {
+    const cursor = getBlockCursor(pos)
+    this.data.writeUInt16LE(stateId, cursor)
   }
 
   setBlockType (pos, id) {

--- a/src/pc/1.9/chunk.js
+++ b/src/pc/1.9/chunk.js
@@ -177,6 +177,11 @@ class Chunk {
     // polyfill
   }
 
+  getBlockStateId (pos) {
+    const cursor = getBlockCursor(pos)
+    return this.data.readUInt16LE(cursor)
+  }
+
   getBlockType (pos) {
     var cursor = getBlockCursor(pos)
     return this.data.readUInt16LE(cursor) >> 4
@@ -200,6 +205,11 @@ class Chunk {
   getBiome (pos) {
     var cursor = getBiomeCursor(pos)
     return this.data.readUInt8(cursor)
+  }
+
+  setBlockStateId (pos, stateId) {
+    const cursor = getBlockCursor(pos)
+    this.data.writeUInt16LE(stateId, cursor)
   }
 
   setBlockType (pos, id) {


### PR DESCRIPTION
This brings older versions closer to 1.13. This would allow to write:
```javascript
  bot._client.on('block_change', (packet) => {
      const pt = new Vec3(packet.location.x, packet.location.y, packet.location.z)
      updateBlockState(pt, packet.type)
  })
```
in mineflayer's blocks.js, for all versions, instead of the version specific:
```javascript
  if (['1.13', '1.13.1', '1.13.2'].includes(bot.version)) {
    bot._client.on('block_change', (packet) => {
      const pt = new Vec3(packet.location.x, packet.location.y, packet.location.z)
      updateBlockState(pt, packet.type)
    })
  } else {
    bot._client.on('block_change', (packet) => {
      const pt = new Vec3(packet.location.x, packet.location.y, packet.location.z)
      updateBlock(pt, packet.type >> 4, packet.type & 0x0f)
    })
  }
```
Additionally it will improve the performances a bit by avoiding spliting and then joining the type and data.