### PR TITLE
Remove dependencie on vec3

### DIFF
--- a/benchmarks/chunk-1.9.js
+++ b/benchmarks/chunk-1.9.js
@@ -1,7 +1,6 @@
 const blocks = require('minecraft-data')('1.12.2').blocks
 const chunk = require('../src/pc/1.9/chunk.js')
 const Block = require('prismarine-block')('1.12.2')
-const Vec3 = require('vec3')
 
 const blockCounts = Object.keys(blocks).length
 const Chunk = chunk('1.12.1')
@@ -17,8 +16,8 @@ function benchmark () {
     const c = new Chunk()
 
     c.initialize(initBlock)
-    const block = c.getBlock(new Vec3(0, 0, 0))
-    c.setBlock(new Vec3(0, 0, 0), block)
+    const block = c.getBlock({ x: 0, y: 0, z: 0 })
+    c.setBlock({ x: 0, y: 0, z: 0 }, block)
 
     const buffer = c.dump()
     const c2 = new Chunk()

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "prismarine-block": "^1.2.0",
     "protodef": "^1.3.1",
     "smart-buffer": "^4.1.0",
-    "uint4": "^0.1.2",
-    "vec3": "^0.1.3"
+    "uint4": "^0.1.2"
   },
   "engines": {
     "node": ">=12"

--- a/src/pc/1.13/ChunkSection.test.js
+++ b/src/pc/1.13/ChunkSection.test.js
@@ -1,5 +1,4 @@
 /* globals describe test */
-const Vec3 = require('vec3').Vec3
 const ChunkSection = require('./ChunkSection')
 const constants = require('./constants')
 const assert = require('assert')
@@ -7,11 +6,11 @@ const assert = require('assert')
 describe('ChunkSection', () => {
   test('insert into middle of palette', () => {
     const section = new ChunkSection()
-    section.setBlock(new Vec3(0, 0, 0), 14)
-    section.setBlock(new Vec3(0, 1, 0), 1)
+    section.setBlock({ x: 0, y: 0, z: 0 }, 14)
+    section.setBlock({ x: 0, y: 1, z: 0 }, 1)
 
-    assert.strictEqual(section.getBlock(new Vec3(0, 0, 0)), 14)
-    assert.strictEqual(section.getBlock(new Vec3(0, 1, 0)), 1)
+    assert.strictEqual(section.getBlock({ x: 0, y: 0, z: 0 }), 14)
+    assert.strictEqual(section.getBlock({ x: 0, y: 1, z: 0 }), 1)
   })
 
   test('switch to global palette', () => {

--- a/src/pc/1.8/chunk.js
+++ b/src/pc/1.8/chunk.js
@@ -1,9 +1,8 @@
 const Section = require('./section')
-const Vec3 = require('vec3').Vec3
 
 const w = Section.w
 const l = Section.l
-const sh = Section.sh// section height
+const sh = Section.sh // section height
 const sectionCount = 16
 const h = sh * sectionCount
 
@@ -30,7 +29,7 @@ const getBiomeCursor = function (pos) {
 }
 
 function posInSection (pos) {
-  return pos.modulus(new Vec3(w, l, sh))
+  return { x: pos.x & 15, y: pos.y & 15, z: pos.z & 15 }
 }
 
 function parseBitMap (bitMap) {

--- a/src/pe/0.14/chunk.js
+++ b/src/pe/0.14/chunk.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Vec3 = require('vec3').Vec3
 const w = 16
 const l = 16
 const h = 128
@@ -79,7 +78,7 @@ class Chunk {
   }
 
   initialize (iniFunc) {
-    const p = new Vec3(0, 0, 0)
+    const p = { x: 0, y: 0, z: 0 }
     for (p.y = 0; p.y < h; p.y++) {
       for (p.z = 0; p.z < w; p.z++) {
         for (p.x = 0; p.x < l; p.x++) {

--- a/src/pe/1.0/chunk.js
+++ b/src/pe/1.0/chunk.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const SubChunk = require('./subchunk')
-const Vec3 = require('vec3')
 
 const BIOME_ID_SIZE = 256
 const HEIGHT_SIZE = 256 * 2
@@ -23,6 +22,10 @@ let Block
 
 function exists (val) {
   return val !== undefined
+}
+
+function posInSection (pos) {
+  return { x: pos.x, y: pos.y & 15, z: pos.z }
 }
 
 class Chunk {
@@ -54,7 +57,7 @@ class Chunk {
   }
 
   initialize (iniFunc) {
-    const p = new Vec3(0, 0, 0)
+    const p = { x: 0, y: 0, z: 0 }
     for (p.y = 0; p.y < Chunk.h; p.y++) {
       for (p.z = 0; p.z < Chunk.w; p.z++) {
         for (p.x = 0; p.x < Chunk.l; p.x++) {
@@ -82,42 +85,42 @@ class Chunk {
 
   getBlockType (pos) {
     const chunk = this.chunks[pos.y >> 4]
-    return chunk.getBlockType(new Vec3(pos.x, pos.y - 16 * (pos.y >> 4), pos.z))
+    return chunk.getBlockType(posInSection(pos))
   }
 
   setBlockType (pos, type) {
     const chunk = this.chunks[pos.y >> 4]
-    chunk.setBlockType(new Vec3(pos.x, pos.y - 16 * (pos.y >> 4), pos.z), type)
+    chunk.setBlockType(posInSection(pos), type)
   }
 
   getBlockData (pos) {
     const chunk = this.chunks[pos.y >> 4]
-    return chunk.getBlockData(new Vec3(pos.x, pos.y - 16 * (pos.y >> 4), pos.z))
+    return chunk.getBlockData(posInSection(pos))
   }
 
   setBlockData (pos, data) {
     const chunk = this.chunks[pos.y >> 4]
-    chunk.setBlockData(new Vec3(pos.x, pos.y - 16 * (pos.y >> 4), pos.z), data)
+    chunk.setBlockData(posInSection(pos), data)
   }
 
   getBlockLight (pos) {
     const chunk = this.chunks[pos.y >> 4]
-    return chunk.getBlockLight(new Vec3(pos.x, pos.y - 16 * (pos.y >> 4), pos.z))
+    return chunk.getBlockLight(posInSection(pos), pos.z)
   }
 
   setBlockLight (pos, light) {
     const chunk = this.chunks[pos.y >> 4]
-    chunk.setBlockLight(new Vec3(pos.x, pos.y - 16 * (pos.y >> 4), pos.z), light)
+    chunk.setBlockLight(posInSection(pos), light)
   }
 
   getSkyLight (pos) {
     const chunk = this.chunks[pos.y >> 4]
-    return chunk.getSkyLight(new Vec3(pos.x, pos.y - 16 * (pos.y >> 4), pos.z))
+    return chunk.getSkyLight(posInSection(pos))
   }
 
   setSkyLight (pos, light) {
     const chunk = this.chunks[pos.y >> 4]
-    chunk.setSkyLight(new Vec3(pos.x, pos.y - 16 * (pos.y >> 4), pos.z), light)
+    chunk.setSkyLight(posInSection(pos), light)
   }
 
   getBiomeColor (pos) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,6 @@
 /* eslint-env mocha */
 
 const assert = require('assert')
-const Vec3 = require('vec3').Vec3
 const fs = require('fs')
 const path = require('path')
 const prismarineBlockLoader = require('prismarine-block')
@@ -43,47 +42,47 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
   test('Defaults to all blocks being air', function () {
     const chunk = new Chunk()
 
-    assert.strictEqual(0, chunk.getBlock(new Vec3(0, 0, 0)).type)
-    assert.strictEqual(0, chunk.getBlock(new Vec3(15, Chunk.h - 1, 15)).type)
+    assert.strictEqual(0, chunk.getBlock({ x: 0, y: 0, z: 0 }).type)
+    assert.strictEqual(0, chunk.getBlock({ x: 15, y: Chunk.h - 1, z: 15 }).type)
   })
 
   test('Should set a block at the given position', function () {
     const chunk = new Chunk()
 
-    chunk.setBlock(new Vec3(0, 0, 0), new Block(5, 0, 2)) // Birch planks, if you're wondering
-    assert.strictEqual(5, chunk.getBlock(new Vec3(0, 0, 0)).type)
+    chunk.setBlock({ x: 0, y: 0, z: 0 }, new Block(5, 0, 2)) // Birch planks, if you're wondering
+    assert.strictEqual(5, chunk.getBlock({ x: 0, y: 0, z: 0 }).type)
     if (!version.startsWith('1.13')) {
-      assert.strictEqual(2, chunk.getBlock(new Vec3(0, 0, 0)).metadata)
+      assert.strictEqual(2, chunk.getBlock({ x: 0, y: 0, z: 0 }).metadata)
     }
 
-    chunk.setBlock(new Vec3(0, 37, 0), new Block(42, 0, 0)) // Iron block
-    assert.strictEqual(42, chunk.getBlock(new Vec3(0, 37, 0)).type)
+    chunk.setBlock({ x: 0, y: 37, z: 0 }, new Block(42, 0, 0)) // Iron block
+    assert.strictEqual(42, chunk.getBlock({ x: 0, y: 37, z: 0 }).type)
     if (!version.startsWith('1.13')) {
-      assert.strictEqual(0, chunk.getBlock(new Vec3(0, 37, 0)).metadata)
+      assert.strictEqual(0, chunk.getBlock({ x: 0, y: 37, z: 0 }).metadata)
     }
 
-    chunk.setBlock(new Vec3(1, 0, 0), new Block(35, 0, 1)) // Orange wool
-    assert.strictEqual(35, chunk.getBlock(new Vec3(1, 0, 0)).type)
+    chunk.setBlock({ x: 1, y: 0, z: 0 }, new Block(35, 0, 1)) // Orange wool
+    assert.strictEqual(35, chunk.getBlock({ x: 1, y: 0, z: 0 }).type)
     if (!version.startsWith('1.13')) {
-      assert.strictEqual(1, chunk.getBlock(new Vec3(1, 0, 0)).metadata)
+      assert.strictEqual(1, chunk.getBlock({ x: 1, y: 0, z: 0 }).metadata)
     }
   })
 
   test('Overwrites blocks in place', function () {
     const chunk = new Chunk()
 
-    chunk.setBlock(new Vec3(0, 1, 0), new Block(42, 0, 0)) // Iron block
-    chunk.setBlock(new Vec3(0, 1, 0), new Block(41, 0, 0)) // Gold block
-    assert.strictEqual(41, chunk.getBlock(new Vec3(0, 1, 0)).type)
+    chunk.setBlock({ x: 0, y: 1, z: 0 }, new Block(42, 0, 0)) // Iron block
+    chunk.setBlock({ x: 0, y: 1, z: 0 }, new Block(41, 0, 0)) // Gold block
+    assert.strictEqual(41, chunk.getBlock({ x: 0, y: 1, z: 0 }).type)
     if (!version.startsWith('1.13')) {
-      assert.strictEqual(0, chunk.getBlock(new Vec3(0, 1, 0)).metadata)
+      assert.strictEqual(0, chunk.getBlock({ x: 0, y: 1, z: 0 }).metadata)
     }
 
-    chunk.setBlock(new Vec3(5, 5, 5), new Block(35, 0, 1)) // Orange wool
-    chunk.setBlock(new Vec3(5, 5, 5), new Block(35, 0, 14)) // Red wool
-    assert.strictEqual(35, chunk.getBlock(new Vec3(5, 5, 5)).type)
+    chunk.setBlock({ x: 5, y: 5, z: 5 }, new Block(35, 0, 1)) // Orange wool
+    chunk.setBlock({ x: 5, y: 5, z: 5 }, new Block(35, 0, 14)) // Red wool
+    assert.strictEqual(35, chunk.getBlock({ x: 5, y: 5, z: 5 }).type)
     if (!version.startsWith('1.13')) {
-      assert.strictEqual(14, chunk.getBlock(new Vec3(5, 5, 5)).metadata)
+      assert.strictEqual(14, chunk.getBlock({ x: 5, y: 5, z: 5 }).metadata)
     }
   })
 
@@ -108,17 +107,17 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
     test('Loads and dumps fake data consistently', function () {
       const chunk = new Chunk()
 
-      chunk.setBlock(new Vec3(0, 37, 0), new Block(42, 0, 0))
-      assert.strictEqual(chunk.getBlock(new Vec3(0, 37, 0)).metadata, 0)
-      assert.strictEqual(chunk.getBlock(new Vec3(0, 37, 0)).type, 42)
+      chunk.setBlock({ x: 0, y: 37, z: 0 }, new Block(42, 0, 0))
+      assert.strictEqual(chunk.getBlock({ x: 0, y: 37, z: 0 }).metadata, 0)
+      assert.strictEqual(chunk.getBlock({ x: 0, y: 37, z: 0 }).type, 42)
       const buf = chunk.dump()
       const chunk1Mask = chunk.getMask()
       const chunk2 = new Chunk()
 
       chunk2.load(buf, chunk1Mask)
 
-      assert.strictEqual(chunk2.getBlock(new Vec3(0, 37, 0)).type, 42)
-      assert.strictEqual(chunk2.getBlock(new Vec3(0, 37, 0)).metadata, 0)
+      assert.strictEqual(chunk2.getBlock({ x: 0, y: 37, z: 0 }).type, 42)
+      assert.strictEqual(chunk2.getBlock({ x: 0, y: 37, z: 0 }).metadata, 0)
 
       const buf2 = chunk2.dump()
       const chunk2Mask = chunk.getMask()
@@ -158,7 +157,7 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
         const chunk2 = new Chunk()
         chunk2.load(buffer, bitmap, data.skyLightSent)
 
-        const p = new Vec3(0, 0, 0)
+        const p = { x: 0, y: 0, z: 0 }
         for (p.y = 0; p.y < 256; p.y++) {
           for (p.z = 0; p.z < 16; p.z++) {
             for (p.x = 0; p.x < 16; p.x++) {
@@ -193,7 +192,7 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
         const chunk2 = Chunk.fromJson(j)
         console.log('loading json', version, performance.now() - a)
 
-        const p = new Vec3(0, 0, 0)
+        const p = { x: 0, y: 0, z: 0 }
         for (p.y = 0; p.y < 256; p.y++) {
           for (p.z = 0; p.z < 16; p.z++) {
             for (p.x = 0; p.x < 16; p.x++) {


### PR DESCRIPTION
This removes every usage of Vec3 and replace it with anonymous objects.
Constructing objects is expensive.
This speeds a bit the internals of prismarine-chunks, but more importantly it relaxes the api by allowing the user to provide any object with x, y, z properties.
It doesn't break the compatibility with other modules that uses Vec3.