### PR TITLE
Fix a json bug + biomes bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Return the chunk bitmap 0b0000_0000_0000_0000(0x0000) means no chunks are set wh
 
 Returns the chunk raw data
 
-#### Chunk.load(data,bitmap=0xFFFF,skyLightSent = true)
+#### Chunk.load(data, bitmap = 0xFFFF, skyLightSent = true, fullChunk = true)
 
 Load raw `data` into the chunk
 

--- a/src/pc/1.13/BitArray.js
+++ b/src/pc/1.13/BitArray.js
@@ -23,17 +23,17 @@ class BitArray {
 
   toJson () {
     return JSON.stringify({
-      data: this.data.map(d => d.toString()),
+      data: this.data,
       capacity: this.capacity,
-      bitsPerValue: this.bitsPerValue.toString(),
-      valueMask: this.valueMask.toString()
+      bitsPerValue: this.bitsPerValue,
+      valueMask: this.valueMask
     })
   }
 
   static fromJson (j) {
     const parsed = JSON.parse(j)
     const bitarray = new BitArray(null)
-    bitarray.data = parsed.data.map(d => d)
+    bitarray.data = parsed.data
     bitarray.capacity = parsed.capacity
     bitarray.bitsPerValue = parsed.bitsPerValue
     bitarray.valueMask = parsed.valueMask

--- a/src/pc/1.13/ChunkColumn.js
+++ b/src/pc/1.13/ChunkColumn.js
@@ -169,7 +169,7 @@ module.exports = (Block, mcData) => {
       return smartBuffer.toBuffer()
     }
 
-    load (data, bitMap = 0xffff, skyLightSent = true) {
+    load (data, bitMap = 0xffff, skyLightSent = true, fullChunk = true) {
       // make smartbuffer from node buffer
       // so that we doesn't need to maintain a cursor
       const reader = SmartBuffer.fromBuffer(data)
@@ -233,10 +233,12 @@ module.exports = (Block, mcData) => {
       }
 
       // read biomes
-      const p = { x: 0, y: 0, z: 0 }
-      for (p.z = 0; p.z < constants.SECTION_WIDTH; p.z++) {
-        for (p.x = 0; p.x < constants.SECTION_WIDTH; p.x++) {
-          this.setBiome(p, reader.readInt32BE())
+      if (fullChunk) {
+        const p = { x: 0, y: 0, z: 0 }
+        for (p.z = 0; p.z < constants.SECTION_WIDTH; p.z++) {
+          for (p.x = 0; p.x < constants.SECTION_WIDTH; p.x++) {
+            this.setBiome(p, reader.readInt32BE())
+          }
         }
       }
     }

--- a/src/pc/1.14/ChunkColumn.js
+++ b/src/pc/1.14/ChunkColumn.js
@@ -209,7 +209,7 @@ module.exports = (Block, mcData) => {
       return smartBuffer.toBuffer()
     }
 
-    load (data, bitMap = 0xffff) {
+    load (data, bitMap = 0xffff, skyLightSent = true, fullChunk = true) {
       // make smartbuffer from node buffer
       // so that we doesn't need to maintain a cursor
       const reader = SmartBuffer.fromBuffer(data)
@@ -261,10 +261,12 @@ module.exports = (Block, mcData) => {
       }
 
       // read biomes
-      const p = { x: 0, y: 0, z: 0 }
-      for (p.z = 0; p.z < constants.SECTION_WIDTH; p.z++) {
-        for (p.x = 0; p.x < constants.SECTION_WIDTH; p.x++) {
-          this.setBiome(p, reader.readInt32BE())
+      if (fullChunk) {
+        const p = { x: 0, y: 0, z: 0 }
+        for (p.z = 0; p.z < constants.SECTION_WIDTH; p.z++) {
+          for (p.x = 0; p.x < constants.SECTION_WIDTH; p.x++) {
+            this.setBiome(p, reader.readInt32BE())
+          }
         }
       }
     }


### PR DESCRIPTION
First bug:
When going to json and back again, the bitsPerValue property gets converted to string and never converted back. This causes an interesting issue at line https://github.com/Karang/prismarine-chunk/blob/045175e09f4e123f4ffa9b3c735dff6c74af0f67/src/pc/1.13/BitArray.js#L72 where the + become a concatenation...

Second bug:
As reported several time (last in date https://github.com/PrismarineJS/mineflayer/issues/1041), when fullChunk (groundUp) is false, the biomes array is not present in the packet. This PR adds the possibility to give a fullChunk parameter to the load function. Changes are needed in mineflayer to fix the bug.