### PR TITLE
add overflow test for bitarray

### DIFF
--- a/src/pc/common/BitArray.js
+++ b/src/pc/common/BitArray.js
@@ -67,15 +67,15 @@ class BitArray {
 
     // Clear bits of this value first
     this.data[startLongIndex] =
-      (this.data[startLongIndex] & ~(this.valueMask << indexInStartLong)) |
-      ((value & this.valueMask) << indexInStartLong)
+      ((this.data[startLongIndex] & ~(this.valueMask << indexInStartLong)) |
+      ((value & this.valueMask) << indexInStartLong)) >>> 0
     const endBitOffset = indexInStartLong + this.bitsPerValue
     if (endBitOffset > 32) {
       // Value stretches across multiple longs
       this.data[startLongIndex + 1] =
-        (this.data[startLongIndex + 1] &
+        ((this.data[startLongIndex + 1] &
           ~((1 << (endBitOffset - 32)) - 1)) |
-        (value >> (32 - indexInStartLong))
+        (value >> (32 - indexInStartLong))) >>> 0
     }
   }
 

--- a/src/pc/common/BitArray.test.js
+++ b/src/pc/common/BitArray.test.js
@@ -59,7 +59,6 @@ describe('BitArray', () => {
       bitArr.set(i, 15)
       assert.strictEqual(bitArr.get(i), 15)
     }
-    console.log(bitArr)
     assert(bitArr.data[0] > 0, `${bitArr.data[0]} is negative`)
   })
 

--- a/src/pc/common/BitArray.test.js
+++ b/src/pc/common/BitArray.test.js
@@ -50,6 +50,19 @@ describe('BitArray', () => {
     }
   })
 
+  test('does not overflow', () => {
+    const bitArr = new BitArray({
+      bitsPerValue: 4,
+      capacity: 4096
+    })
+    for (let i = 0; i < 8; ++i) {
+      bitArr.set(i, 15)
+      assert.strictEqual(bitArr.get(i), 15)
+    }
+    console.log(bitArr)
+    assert(bitArr.data[0] > 0, `${bitArr.data[0]} is negative`)
+  })
+
   test('throws when writing out of bounds', () => {
     const bitArr = new BitArray({
       bitsPerValue: 4,

--- a/test/test.js
+++ b/test/test.js
@@ -76,12 +76,14 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
     assert.strictEqual(5, chunk.getBlock(new Vec3(0, 0, 0)).type)
     chunk.setSkyLight(new Vec3(0, 0, 0), 15)
     assert.strictEqual(15, chunk.getSkyLight(new Vec3(0, 0, 0)))
-    const buffer = chunk.dump()
-    const bitmap = chunk.getMask()
-    const chunk2 = new Chunk()
-    chunk2.load(buffer, bitmap, true)
+    if (!version.startsWith('1.8') && !version.startsWith('1.14') && !version.startsWith('1.15')) {
+      const buffer = chunk.dump()
+      const bitmap = chunk.getMask()
+      const chunk2 = new Chunk()
+      chunk2.load(buffer, bitmap, true)
 
-    assert.strictEqual(15, chunk2.getSkyLight(new Vec3(0, 0, 0)))
+      assert.strictEqual(15, chunk2.getSkyLight(new Vec3(0, 0, 0)))
+    }
   })
 
   test('Block light set/get', function () {
@@ -91,12 +93,14 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
     assert.strictEqual(5, chunk.getBlock(new Vec3(0, 0, 0)).type)
     chunk.setBlockLight(new Vec3(0, 0, 0), 15)
     assert.strictEqual(15, chunk.getBlockLight(new Vec3(0, 0, 0)))
-    const buffer = chunk.dump()
-    const bitmap = chunk.getMask()
-    const chunk2 = new Chunk()
-    chunk2.load(buffer, bitmap, true)
+    if (!version.startsWith('1.8') && !version.startsWith('1.14') && !version.startsWith('1.15')) {
+      const buffer = chunk.dump()
+      const bitmap = chunk.getMask()
+      const chunk2 = new Chunk()
+      chunk2.load(buffer, bitmap, true)
 
-    assert.strictEqual(15, chunk2.getBlockLight(new Vec3(0, 0, 0)))
+      assert.strictEqual(15, chunk2.getBlockLight(new Vec3(0, 0, 0)))
+    }
   })
 
   test('Overwrites blocks in place', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -84,6 +84,21 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
     assert.strictEqual(15, chunk2.getSkyLight(new Vec3(0, 0, 0)))
   })
 
+  test('Block light set/get', function () {
+    const chunk = new Chunk()
+
+    chunk.setBlock(new Vec3(0, 0, 0), new Block(5, 0, 2)) // Birch planks, if you're wondering
+    assert.strictEqual(5, chunk.getBlock(new Vec3(0, 0, 0)).type)
+    chunk.setBlockLight(new Vec3(0, 0, 0), 15)
+    assert.strictEqual(15, chunk.getBlockLight(new Vec3(0, 0, 0)))
+    const buffer = chunk.dump()
+    const bitmap = chunk.getMask()
+    const chunk2 = new Chunk()
+    chunk2.load(buffer, bitmap, true)
+
+    assert.strictEqual(15, chunk2.getBlockLight(new Vec3(0, 0, 0)))
+  })
+
   test('Overwrites blocks in place', function () {
     const chunk = new Chunk()
 

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,12 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
     assert.strictEqual(5, chunk.getBlock(new Vec3(0, 0, 0)).type)
     chunk.setSkyLight(new Vec3(0, 0, 0), 15)
     assert.strictEqual(15, chunk.getSkyLight(new Vec3(0, 0, 0)))
+    const buffer = chunk.dump()
+    const bitmap = chunk.getMask()
+    const chunk2 = new Chunk()
+    chunk2.load(buffer, bitmap, true)
+
+    assert.strictEqual(15, chunk2.getSkyLight(new Vec3(0, 0, 0)))
   })
 
   test('Overwrites blocks in place', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -69,6 +69,15 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
     }
   })
 
+  test('Skylight set/get', function () {
+    const chunk = new Chunk()
+
+    chunk.setBlock(new Vec3(0, 0, 0), new Block(5, 0, 2)) // Birch planks, if you're wondering
+    assert.strictEqual(5, chunk.getBlock(new Vec3(0, 0, 0)).type)
+    chunk.setSkyLight(new Vec3(0, 0, 0), 15)
+    assert.strictEqual(15, chunk.getSkyLight(new Vec3(0, 0, 0)))
+  })
+
   test('Overwrites blocks in place', function () {
     const chunk = new Chunk()
 
@@ -182,6 +191,23 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
           chunk2.loadBiomes(dumpedBiomes)
         }
 
+        function eqSet (as, bs) {
+          if (as.size !== bs.size) return false
+          for (var a of as) if (!bs.has(a)) return false
+          return true
+        }
+
+        if (chunk.sections) {
+          assert.strictEqual(chunk.sections.length, chunk2.sections.length)
+          for (let i = 0; i < chunk.sections.length; i++) {
+            if (chunk.sections[i] !== null && chunk.sections[i].palette !== undefined) {
+              const s1 = new Set(chunk.sections[i].palette)
+              const s2 = new Set(chunk2.sections[i].palette)
+              assert(eqSet(s1, s2), `palettes are not equal ${[...s1]} != ${[...s2]}`)
+            }
+          }
+        }
+
         const p = new Vec3(0, 0, 0)
         for (p.y = 0; p.y < 256; p.y++) {
           for (p.z = 0; p.z < 16; p.z++) {
@@ -201,13 +227,19 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
             }
           }
         }
+        if (!version.startsWith('1.8')) {
+          assert(Buffer.compare(dump, buffer) === 0, 'chunk buffers are not equal')
+        }
       })
 
       test('Correctly cycles through chunks json ' + chunkDump, () => {
+        const measurePerformance = false
         let a = performance.now()
         const chunk = new Chunk()
-        console.log('creation', version, performance.now() - a)
-        a = performance.now()
+        if (measurePerformance) {
+          console.log('creation', version, performance.now() - a)
+          a = performance.now()
+        }
         chunk.load(dump, data.bitMap, data.skyLightSent)
         if (version.startsWith('1.14') || version.startsWith('1.15')) {
           chunk.loadLight(lightDump, lightData.skyLightMask, lightData.blockLightMask, lightData.emptySkyLightMask, lightData.emptyBlockLightMask)
@@ -216,13 +248,19 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
         if (version.startsWith('1.15')) {
           chunk.loadBiomes(data.biomes)
         }
-        console.log('loading', version, performance.now() - a)
-        a = performance.now()
+        if (measurePerformance) {
+          console.log('loading', version, performance.now() - a)
+          a = performance.now()
+        }
         const j = chunk.toJson()
-        console.log('seria json', version, performance.now() - a)
-        a = performance.now()
+        if (measurePerformance) {
+          console.log('seria json', version, performance.now() - a)
+          a = performance.now()
+        }
         const chunk2 = Chunk.fromJson(j)
-        console.log('loading json', version, performance.now() - a)
+        if (measurePerformance) {
+          console.log('loading json', version, performance.now() - a)
+        }
 
         const p = new Vec3(0, 0, 0)
         for (p.y = 0; p.y < 256; p.y++) {

--- a/test/test.js
+++ b/test/test.js
@@ -144,6 +144,7 @@ describe.each(depsByVersion)('Chunk implementation for minecraft %s', (version, 
       const data = JSON.parse(
         fs.readFileSync(path.join(folder, packetData)).toString()
       )
+      data.skylightSent = !packetData.includes('nether') && !packetData.includes('end')
 
       let lightDump, lightData
       if (version.startsWith('1.14') || version.startsWith('1.15')) {


### PR DESCRIPTION
I added this failing test to reproduce the problem (hit in https://github.com/PrismarineJS/flying-squid/issues/394)
I'm not sure how to fix. I thought you may have ideas on this @Karang 
issue : when assigning 8 bits to maximum value (15 in this case), the first int of the bitarray overflows and goes to negative. .set and .get works as expected with this. However writeBuffer doesn't work and I'm wondering about readBuffer
what do we want to do in this case ?
It should be possible to handle this without any negative int rights ?
I'm thinking we should do something in this line https://github.com/PrismarineJS/prismarine-chunk/blob/master/src/pc/common/BitArray.js#L69