### PR TITLE
Discard the 0 length of the missing palette array

### DIFF
--- a/src/pc/1.9/ChunkColumn.js
+++ b/src/pc/1.9/ChunkColumn.js
@@ -206,6 +206,8 @@ module.exports = (Block, mcData) => {
             palette.push(varInt.read(reader))
           }
         } else {
+          // remove the 0 length signifying the missing palette array
+          varInt.read(reader)
           // global palette is used
           palette = null
         }


### PR DESCRIPTION
When the global palette is used instead of the per section palette the 0 length of the palette array is still sent (see below), meaning the read for the length of the block array will read the wrong length. This pull request simply discards the dangling length
![image](https://user-images.githubusercontent.com/16208640/89686485-252e2100-d907-11ea-84b1-692155cb3b72.png)
