### PR TITLE
Write 0 length for missing palette when dumping

### DIFF
--- a/src/pc/1.9/ChunkSection.js
+++ b/src/pc/1.9/ChunkSection.js
@@ -176,6 +176,9 @@ class ChunkSection {
       this.palette.forEach(paletteElement => {
         varInt.write(smartBuffer, paletteElement)
       })
+    } else {
+      // write 0 length for missing palette
+      varInt.write(smartBuffer, 0)
     }
 
     // write the number of longs to be written


### PR DESCRIPTION
related to #97, while i fixed the loading, i forgot to fix the dumping.
This is not really important, as the only prismarine project that uses dumping is flying-squid, which isnt able to create chunks with bitPerBlock higher than 8 anyways (which is the point at which the palette is not used anymore), so this can just be merged and wait for the next release instead of making a release just for it.