### PR TITLE
Several different bug fixes

### DIFF
--- a/src/pc/1.13/ChunkColumn.js
+++ b/src/pc/1.13/ChunkColumn.js
@@ -9,6 +9,7 @@ module.exports = (Block, mcData) => {
   return class ChunkColumn {
     constructor () {
       this.sectionMask = 0
+      this.skyLightSent = true
       this.sections = Array(constants.NUM_SECTIONS).fill(null)
       this.biomes = Array(
         constants.SECTION_WIDTH * constants.SECTION_WIDTH
@@ -192,6 +193,7 @@ module.exports = (Block, mcData) => {
       // so that we doesn't need to maintain a cursor
       const reader = SmartBuffer.fromBuffer(data)
 
+      this.skyLightSent = skyLightSent
       this.sectionMask |= bitMap
       for (let y = 0; y < constants.NUM_SECTIONS; ++y) {
         // does `data` contain this chunk?
@@ -245,7 +247,7 @@ module.exports = (Block, mcData) => {
           data: dataArray,
           palette,
           blockLight,
-          ...(skyLightSent ? { skyLight } : {})
+          ...(skyLightSent ? { skyLight } : { skyLight: null })
         })
         this.sections[y] = section
       }

--- a/src/pc/1.13/ChunkSection.js
+++ b/src/pc/1.13/ChunkSection.js
@@ -150,7 +150,7 @@ class ChunkSection {
   }
 
   getSkyLight (pos) {
-    return this.skyLight ? this.skyLight.get(getBlockIndex(pos)) : null
+    return this.skyLight ? this.skyLight.get(getBlockIndex(pos)) : 0
   }
 
   setBlockLight (pos, light) {
@@ -158,7 +158,7 @@ class ChunkSection {
   }
 
   setSkyLight (pos, light) {
-    return this.skyLight ? this.skyLight.set(getBlockIndex(pos), light) : null
+    return this.skyLight ? this.skyLight.set(getBlockIndex(pos), light) : 0
   }
 
   isEmpty () {

--- a/src/pc/1.13/ChunkSection.js
+++ b/src/pc/1.13/ChunkSection.js
@@ -31,7 +31,7 @@ class ChunkSection {
       })
     }
 
-    if (!options.palette) {
+    if (options.palette === undefined) { // dont create palette if its null
       options.palette = [0]
     }
 

--- a/src/pc/1.13/ChunkSection.js
+++ b/src/pc/1.13/ChunkSection.js
@@ -42,7 +42,7 @@ class ChunkSection {
       })
     }
 
-    if (!options.skyLight) {
+    if (options.skyLight === undefined) { // dont create skylight if its null
       options.skyLight = new BitArray({
         bitsPerValue: 4,
         capacity: constants.SECTION_VOLUME
@@ -63,7 +63,7 @@ class ChunkSection {
       palette: this.palette,
       isDirty: this.isDirty,
       blockLight: this.blockLight.toJson(),
-      skyLight: this.skyLight.toJson(),
+      skyLight: this.skyLight ? this.skyLight.toJson() : this.skyLight,
       solidBlockCount: this.solidBlockCount
     })
   }
@@ -74,7 +74,7 @@ class ChunkSection {
       data: BitArray.fromJson(parsed.data),
       palette: parsed.palette,
       blockLight: BitArray.fromJson(parsed.blockLight),
-      skyLight: BitArray.fromJson(parsed.skyLight),
+      skyLight: parsed.skyLight ? BitArray.fromJson(parsed.skyLight) : parsed.skyLight,
       solidBlockCount: parsed.solidBlockCount
     })
   }
@@ -150,7 +150,7 @@ class ChunkSection {
   }
 
   getSkyLight (pos) {
-    return this.skyLight.get(getBlockIndex(pos))
+    return this.skyLight ? this.skyLight.get(getBlockIndex(pos)) : null
   }
 
   setBlockLight (pos, light) {
@@ -158,7 +158,7 @@ class ChunkSection {
   }
 
   setSkyLight (pos, light) {
-    return this.skyLight.set(getBlockIndex(pos), light)
+    return this.skyLight ? this.skyLight.set(getBlockIndex(pos), light) : null
   }
 
   isEmpty () {
@@ -186,8 +186,10 @@ class ChunkSection {
     // write block light data
     this.blockLight.writeBuffer(smartBuffer)
 
-    // write sky light data
-    this.skyLight.writeBuffer(smartBuffer)
+    if (this.skyLight !== null) {
+      // write sky light data
+      this.skyLight.writeBuffer(smartBuffer)
+    }
   }
 }
 

--- a/src/pc/1.14/ChunkSection.js
+++ b/src/pc/1.14/ChunkSection.js
@@ -31,7 +31,7 @@ class ChunkSection {
       })
     }
 
-    if (!options.palette) {
+    if (options.palette === undefined) { // dont create palette if its null
       options.palette = [0]
     }
 

--- a/src/pc/1.15/ChunkSection.js
+++ b/src/pc/1.15/ChunkSection.js
@@ -31,7 +31,7 @@ class ChunkSection {
       })
     }
 
-    if (!options.palette) {
+    if (options.palette === undefined) { // dont create palette if its null
       options.palette = [0]
     }
 

--- a/src/pc/1.16/ChunkSection.js
+++ b/src/pc/1.16/ChunkSection.js
@@ -31,7 +31,7 @@ class ChunkSection {
       })
     }
 
-    if (!options.palette) {
+    if (options.palette === undefined) { // dont create palette if its null
       options.palette = [0]
     }
 

--- a/src/pc/1.8/chunk.js
+++ b/src/pc/1.8/chunk.js
@@ -229,7 +229,7 @@ class Chunk {
       }
     }
     if (fullChunk) {
-      data.copy(this.biome, w * l * sectionCount * chunkCount * (skyLightSent ? 3 : 5 / 2))
+      data.copy(this.biome, 0, w * l * sectionCount * chunkCount * (skyLightSent ? 3 : 5 / 2))
     }
 
     const expectedSize = SECTION_SIZE * chunkCount + (fullChunk ? w * l : 0)

--- a/src/pc/1.8/chunk.js
+++ b/src/pc/1.8/chunk.js
@@ -224,7 +224,7 @@ class Chunk {
         const sectionBuffer = Buffer.alloc(SECTION_SIZE)
         offset += data.copy(sectionBuffer, 0, offset, offset + w * l * sh * 2)
         offsetLight += data.copy(sectionBuffer, w * l * sh * 2, offsetLight, offsetLight + w * l * sh / 2)
-        if (this.skyLightSent) offsetSkyLight += data.copy(sectionBuffer, w * l * sh * 5 / 2, offsetLight, offsetSkyLight + w * l * sh / 2)
+        if (this.skyLightSent) offsetSkyLight += data.copy(sectionBuffer, w * l * sh * 5 / 2, offsetSkyLight, offsetSkyLight + w * l * sh / 2)
         this.sections[i].load(sectionBuffer, skyLightSent)
       }
     }

--- a/src/pc/1.9/ChunkColumn.js
+++ b/src/pc/1.9/ChunkColumn.js
@@ -10,6 +10,7 @@ module.exports = (Block, mcData) => {
   return class ChunkColumn {
     constructor () {
       this.sectionMask = 0
+      this.skyLightSent = true
       this.sections = Array(constants.NUM_SECTIONS).fill(null)
       this.biomes = Array(
         constants.SECTION_WIDTH * constants.SECTION_WIDTH
@@ -180,6 +181,7 @@ module.exports = (Block, mcData) => {
       // so that we doesn't need to maintain a cursor
       const reader = SmartBuffer.fromBuffer(data)
 
+      this.skyLightSent = skyLightSent
       this.sectionMask |= bitMap
       for (let y = 0; y < constants.NUM_SECTIONS; ++y) {
         // does `data` contain this chunk?
@@ -235,7 +237,7 @@ module.exports = (Block, mcData) => {
           data: dataArray,
           palette,
           blockLight,
-          ...(skyLightSent ? { skyLight } : {})
+          ...(skyLightSent ? { skyLight } : { skyLight: null })
         })
         this.sections[y] = section
       }

--- a/src/pc/1.9/ChunkSection.js
+++ b/src/pc/1.9/ChunkSection.js
@@ -32,7 +32,7 @@ class ChunkSection {
       })
     }
 
-    if (!options.palette) {
+    if (options.palette === undefined) { // dont create palette if its null
       options.palette = [0]
     }
 

--- a/src/pc/1.9/ChunkSection.js
+++ b/src/pc/1.9/ChunkSection.js
@@ -43,7 +43,7 @@ class ChunkSection {
       })
     }
 
-    if (!options.skyLight) {
+    if (options.skyLight === undefined) { // dont create skylight if its null
       options.skyLight = new BitArray({
         bitsPerValue: 4,
         capacity: constants.SECTION_VOLUME
@@ -64,7 +64,7 @@ class ChunkSection {
       palette: this.palette,
       isDirty: this.isDirty,
       blockLight: this.blockLight.toJson(),
-      skyLight: this.skyLight.toJson(),
+      skyLight: this.skyLight ? this.skyLight.toJson() : this.skyLight,
       solidBlockCount: this.solidBlockCount
     })
   }
@@ -75,7 +75,7 @@ class ChunkSection {
       data: BitArray.fromJson(parsed.data),
       palette: parsed.palette,
       blockLight: BitArray.fromJson(parsed.blockLight),
-      skyLight: BitArray.fromJson(parsed.skyLight),
+      skyLight: parsed.skyLight ? BitArray.fromJson(parsed.skyLight) : parsed.skyLight,
       solidBlockCount: parsed.solidBlockCount
     })
   }
@@ -151,7 +151,7 @@ class ChunkSection {
   }
 
   getSkyLight (pos) {
-    return this.skyLight.get(getBlockIndex(pos))
+    return this.skyLight ? this.skyLight.get(getBlockIndex(pos)) : null
   }
 
   setBlockLight (pos, light) {
@@ -159,7 +159,7 @@ class ChunkSection {
   }
 
   setSkyLight (pos, light) {
-    return this.skyLight.set(getBlockIndex(pos), light)
+    return this.skyLight ? this.skyLight.set(getBlockIndex(pos), light) : null
   }
 
   isEmpty () {
@@ -190,8 +190,10 @@ class ChunkSection {
     // write block light data
     this.blockLight.writeBuffer(smartBuffer)
 
-    // write sky light data
-    this.skyLight.writeBuffer(smartBuffer)
+    if (this.skyLight !== null) {
+      // write sky light data
+      this.skyLight.writeBuffer(smartBuffer)
+    }
   }
 }
 

--- a/src/pc/1.9/ChunkSection.js
+++ b/src/pc/1.9/ChunkSection.js
@@ -151,7 +151,7 @@ class ChunkSection {
   }
 
   getSkyLight (pos) {
-    return this.skyLight ? this.skyLight.get(getBlockIndex(pos)) : null
+    return this.skyLight ? this.skyLight.get(getBlockIndex(pos)) : 0
   }
 
   setBlockLight (pos, light) {
@@ -159,7 +159,7 @@ class ChunkSection {
   }
 
   setSkyLight (pos, light) {
-    return this.skyLight ? this.skyLight.set(getBlockIndex(pos), light) : null
+    return this.skyLight ? this.skyLight.set(getBlockIndex(pos), light) : 0
   }
 
   isEmpty () {


### PR DESCRIPTION
The bugs:

- Chunk implementations for 1.9 - 1.13 didnt actually conform to the skyLightSent standard (by saving a zeroed out skylight instead of not saving it at all), which could cause problems when sending out nether chunks in flying-squid and the like, also added skyLightSent field to the chunks (similar to 1.8) so users can tell if the chunk includes skyLight data or not.
- The chunk implementation for 1.8 accidentally copied the block light data to both the block light buffer and the skylight buffer when loading, essentaily discarding the skylight and replacing it with the blocklight (see note below)
- The chunk implementation for 1.8 accidentally used the offset for the biome data as a target offset instead of a source offset, thereby always copying zeros into the biomes buffer when laoding (see note below)
- The chunk implementations for 1.9-1.16 accidentally ignored the fact the global palette was used when loading, causing them to still allocate (and then write when dumping) an used palette (see note below)

NOTE: All of the bugs with this note should have been caught by a simple consistency test (aka, create fake chunk, dump it, load it, dump it again, and make sure the dump buffers match) but were instead caught during my testing of prismarine-provider-raw, so i think prismarine-chunk's testing needs improvements.

I'd appreciate if a new version could be released as well, as i need it for provider-raw.