### PR TITLE
Set GLOBAL_BITS_PER_BLOCK to 16

### DIFF
--- a/src/pc/common/constants.js
+++ b/src/pc/common/constants.js
@@ -22,7 +22,7 @@ const MAX_BITS_PER_BLOCK = 8
 
 // number of bits used for each block in the global palette.
 // this value should not be hardcoded according to wiki.vg
-const GLOBAL_BITS_PER_BLOCK = 14
+const GLOBAL_BITS_PER_BLOCK = 16
 
 module.exports = {
   CHUNK_HEIGHT,


### PR DESCRIPTION
In recent versions of MC this value is 15, but as a practical matter there's no difference between 15 and 16 (you can still only store 4 values per long), and `BitArray` is slighty more performant  when `bitsPerValue` is a power of two.

The wiki is also right, we shouldn't be hardcoding this, but basing it off the maximum StateID supported by the Minecraft world. But that kind of thing will have to wait for a more complete refactor of the code base.