### PR TITLE
Fix skyLightMask bookkeeping

### DIFF
--- a/src/pc/1.17/ChunkColumn.js
+++ b/src/pc/1.17/ChunkColumn.js
@@ -220,7 +220,7 @@ module.exports = (Block, mcData) => {
           bitsPerValue: 4,
           capacity: 4096
         })
-        this.skyLightMask |= 1 << sectionIndex
+        this.skyLightMask.set(sectionIndex, 1)
         this.skyLightSections[sectionIndex] = section
       }
 


### PR DESCRIPTION
Some dumbass missed updating this line when porting to 1.17. Probably was just trying to get tests to pass or something.