### PR TITLE
prismarine-nbt is missing from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "prismarine-biome": "^1.2.0",
     "prismarine-block": "^1.14.1",
+    "prismarine-nbt": "^2.2.1",
     "prismarine-registry": "^1.1.0",
     "smart-buffer": "^4.1.0",
     "uint4": "^0.1.2",


### PR DESCRIPTION
```
Error: prismarine-chunk tried to access prismarine-nbt, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```

This fixes this issue.