### PR TITLE
add helper function for loading blockentities directly from packet data

### DIFF
--- a/src/pc/common/CommonChunkColumn.js
+++ b/src/pc/common/CommonChunkColumn.js
@@ -61,9 +61,19 @@ class CommonChunkColumn {
     delete this.blockEntities[posKey(pos)]
   }
 
+  loadBlockEntity (entity) {
+  this.setBlockEntity({ x: entity.x.value >> 4, y: entity.y.value, z: entity.z.value >> 4 }, entity)
+  }
+
+  loadNBTBlockEntities (entities) {
+    for (const nbt of entities) {
+      this.loadBlockEntity(nbt.value);
+    }
+  }
+
   loadBlockEntities (entities) {
     for (const entity of entities) {
-      this.setBlockEntity({ x: entity.x.value >> 4, y: entity.y.value, z: entity.z.value >> 4 }, entity)
+      this.loadBlockEntity(entity);
     }
   }
 }


### PR DESCRIPTION
The `blockEntities` array in the [map_chunk](https://minecraft-data.prismarine.js.org/?d=protocol#toClient_map_chunk) packet contains NBT objects that can't be used with `ChunkColumn.loadBlockEntities`. They look like this:

```js
// example of what "blockEntities" can look like
[
  {
    type: 'compound',
    name: '',
    value: { x: [Object], y: [Object], z: [Object], id: [Object] }
  }
]
```
These can't be directly passed to `ChunkColumn.loadBlockEntities`, because the x, y, z coordinates are not stored at the top level of the object. On the other hand, the new method `loadNBTBlockEntities` can be used with this value just fine.