### PR TITLE
Fix loading skylight when in nether

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Get the block light at `pos`
 
 #### Chunk.getSkyLight(pos)
 
-Get the block sky light at `pos`
+Get the block sky light at `pos`. Undefined when world does not have skylight (nether or end in Vanilla)
 
 #### Chunk.getBiome(pos)
 
@@ -223,7 +223,7 @@ See [index.d.ts](https://github.com/PrismarineJS/prismarine-chunk/blob/master/ty
 #### getBlockType(pos: Vec3): number
 #### getBlockData(pos: Vec3): number
 #### getBlockLight(pos: Vec3): number
-#### getSkyLight(pos: Vec3): number
+#### getSkyLight(pos: Vec3): number | undefined
 #### setBlockStateId(pos: Vec3, stateId: number): void
 #### setBlockType(pos: Vec3, id: number): void
 #### setBlockData(pos: Vec3, data: Buffer): void

--- a/src/pc/1.13/ChunkSection.js
+++ b/src/pc/1.13/ChunkSection.js
@@ -150,7 +150,7 @@ class ChunkSection {
   }
 
   getSkyLight (pos) {
-    return this.skyLight ? this.skyLight.get(getBlockIndex(pos)) : 0
+    return this.skyLight ? this.skyLight.get(getBlockIndex(pos)) : undefined
   }
 
   setBlockLight (pos, light) {

--- a/src/pc/1.8/chunk.js
+++ b/src/pc/1.8/chunk.js
@@ -110,7 +110,7 @@ module.exports = (registry) => {
     }
 
     getSkyLight (pos) {
-      if (!this.skyLightSent) return 0
+      if (!this.skyLightSent) return undefined
       const section = this._getSection(pos)
       return section ? section.getSkyLight(posInSection(pos)) : 15
     }

--- a/src/pc/1.9/ChunkSection.js
+++ b/src/pc/1.9/ChunkSection.js
@@ -151,7 +151,7 @@ class ChunkSection {
   }
 
   getSkyLight (pos) {
-    return this.skyLight ? this.skyLight.get(getBlockIndex(pos)) : 0
+    return this.skyLight ? this.skyLight.get(getBlockIndex(pos)) : undefined
   }
 
   setBlockLight (pos, light) {


### PR DESCRIPTION
This fixes a long-standing mineflayer issue (https://github.com/PrismarineJS/mineflayer/issues/2614) that would cause the bot to crash when coming across a sign in the nether

Closes #186 