### PR TITLE
fix: toJson / fromJson didn't use maxBitsPerBlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 benchmarks/results/
 package-lock.json
 .vscode
+.DS_Store

--- a/src/pc/common/PaletteContainer.js
+++ b/src/pc/common/PaletteContainer.js
@@ -113,6 +113,7 @@ class IndirectPaletteContainer {
       type: 'indirect',
       palette: this.palette,
       maxBits: this.maxBits,
+      maxBitsPerBlock: this.maxBitsPerBlock,
       data: this.data.toJson()
     })
   }
@@ -122,6 +123,7 @@ class IndirectPaletteContainer {
     return new IndirectPaletteContainer({
       palette: parsed.palette,
       maxBits: parsed.maxBits,
+      maxBitsPerBlock: parsed.maxBitsPerBlock,
       data: BitArray.fromJson(parsed.data)
     })
   }
@@ -171,7 +173,8 @@ class SingleValueContainer {
       value: this.value,
       bitsPerValue: this.bitsPerValue,
       capacity: this.capacity,
-      maxBits: this.maxBits
+      maxBits: this.maxBits,
+      maxBitsPerBlock: this.maxBitsPerBlock
     })
   }
 
@@ -181,7 +184,8 @@ class SingleValueContainer {
       value: parsed.value,
       bitsPerValue: parsed.bitsPerValue,
       capacity: parsed.capacity,
-      maxBits: parsed.maxBits
+      maxBits: parsed.maxBits,
+      maxBitsPerBlock: parsed.maxBitsPerBlock
     })
   }
 }
@@ -196,14 +200,16 @@ function containerFromJson (j) {
     return new IndirectPaletteContainer({
       palette: parsed.palette,
       maxBits: parsed.maxBits,
-      data: BitArray.fromJson(parsed.data)
+      data: BitArray.fromJson(parsed.data),
+      maxBitsPerBlock: parsed.maxBitsPerBlock
     })
   } else if (parsed.type === 'single') {
     return new SingleValueContainer({
       value: parsed.value,
       bitsPerValue: parsed.bitsPerValue,
       capacity: parsed.capacity,
-      maxBits: parsed.maxBits
+      maxBits: parsed.maxBits,
+      maxBitsPerBlock: parsed.maxBitsPerBlock
     })
   }
   return undefined

--- a/test/ChunkColumn.test.js
+++ b/test/ChunkColumn.test.js
@@ -144,6 +144,17 @@ for (const version of allVersions) {
       assert.strictEqual(3, cc2.getBlockLight(new Vec3(0, 3, 0)))
       assert.strictEqual(4, cc2.getSkyLight(new Vec3(0, 4, 0)))
       assert.strictEqual(cc.toJson(), cc2.toJson())
+
+    })
+    it('to/from JSON work and keep maxBitsPerBlock', () => {
+      const cc = new ChunkColumn()
+      const cc2 = ChunkColumn.fromJson(cc.toJson())
+
+      for (let i = 0; i < 4096; i++) {
+        cc2.setBlockStateId(new Vec3(0, 0, 0), i) // Decides to switch to Direct pallete at some point
+        const blockStateId = cc2.getBlockStateId(new Vec3(0, 0, 0))
+        if (blockStateId !== i) throw new Error(`Expected ${i} but got ${blockStateId}`)
+      }
     })
 
     //

--- a/test/ChunkColumn.test.js
+++ b/test/ChunkColumn.test.js
@@ -144,7 +144,6 @@ for (const version of allVersions) {
       assert.strictEqual(3, cc2.getBlockLight(new Vec3(0, 3, 0)))
       assert.strictEqual(4, cc2.getSkyLight(new Vec3(0, 4, 0)))
       assert.strictEqual(cc.toJson(), cc2.toJson())
-
     })
     it('to/from JSON work and keep maxBitsPerBlock', () => {
       const cc = new ChunkColumn()


### PR DESCRIPTION
Fixes the following code:

```ts
import PChunk from 'prismarine-chunk'
import { Vec3 } from 'vec3'

const Chunk = PChunk('1.18.1')
const chunk = new Chunk(undefined)

const chunk2 = Chunk.fromJson(chunk.toJson()) as any

for (let i = 0; i < 4096; i++) {
    chunk2.setBlockStateId(new Vec3(0, 0, 0), i) // Decides to switch to Direct pallete at some point
    const blockStateId = chunk2.getBlockStateId(new Vec3(0, 0, 0))
    if (blockStateId !== i) throw new Error(`Expected ${i} but got ${blockStateId}`) // Expected 256 but got 0
}
```

Also what about indirect pallete I don't really know what is the correct behavior but it just feels like always adding a new block into pallete on the block replace is not right (since the block doesn't exist in chunk anymore).