### PR TITLE
fix: dumped buffer must not be empty

### DIFF
--- a/src/pc/1.13/ChunkColumn.js
+++ b/src/pc/1.13/ChunkColumn.js
@@ -199,6 +199,10 @@ module.exports = (Block, mcData) => {
         smartBuffer.writeInt32BE(biome)
       })
 
+      if (!smartBuffer.length) {
+        return Buffer.alloc(4096)
+      }
+
       return smartBuffer.toBuffer()
     }
 

--- a/src/pc/1.13/ChunkColumn.js
+++ b/src/pc/1.13/ChunkColumn.js
@@ -200,7 +200,7 @@ module.exports = (Block, mcData) => {
       })
 
       if (!smartBuffer.length) {
-        return Buffer.alloc(4096)
+        return Buffer.alloc(1024)
       }
 
       return smartBuffer.toBuffer()

--- a/src/pc/1.14/ChunkColumn.js
+++ b/src/pc/1.14/ChunkColumn.js
@@ -221,6 +221,10 @@ module.exports = (Block, mcData) => {
         smartBuffer.writeInt32BE(biome)
       })
 
+      if (!smartBuffer.length) {
+        return Buffer.alloc(4096)
+      }
+
       return smartBuffer.toBuffer()
     }
 

--- a/src/pc/1.14/ChunkColumn.js
+++ b/src/pc/1.14/ChunkColumn.js
@@ -222,7 +222,7 @@ module.exports = (Block, mcData) => {
       })
 
       if (!smartBuffer.length) {
-        return Buffer.alloc(4096)
+        return Buffer.alloc(1024)
       }
 
       return smartBuffer.toBuffer()

--- a/src/pc/1.15/ChunkColumn.js
+++ b/src/pc/1.15/ChunkColumn.js
@@ -211,7 +211,7 @@ module.exports = (Block, mcData) => {
         }
       })
       if (!smartBuffer.length) {
-        return Buffer.alloc(4096)
+        return Buffer.alloc(1024)
       }
       return smartBuffer.toBuffer()
     }

--- a/src/pc/1.15/ChunkColumn.js
+++ b/src/pc/1.15/ChunkColumn.js
@@ -210,6 +210,9 @@ module.exports = (Block, mcData) => {
           section.write(smartBuffer)
         }
       })
+      if (!smartBuffer.length) {
+        return Buffer.alloc(4096)
+      }
       return smartBuffer.toBuffer()
     }
 

--- a/src/pc/1.16/ChunkColumn.js
+++ b/src/pc/1.16/ChunkColumn.js
@@ -211,7 +211,7 @@ module.exports = (Block, mcData) => {
         }
       })
       if (!smartBuffer.length) {
-        return Buffer.alloc(4096)
+        return Buffer.alloc(1024)
       }
       return smartBuffer.toBuffer()
     }

--- a/src/pc/1.16/ChunkColumn.js
+++ b/src/pc/1.16/ChunkColumn.js
@@ -210,6 +210,9 @@ module.exports = (Block, mcData) => {
           section.write(smartBuffer)
         }
       })
+      if (!smartBuffer.length) {
+        return Buffer.alloc(4096)
+      }
       return smartBuffer.toBuffer()
     }
 

--- a/src/pc/1.17/ChunkColumn.js
+++ b/src/pc/1.17/ChunkColumn.js
@@ -251,6 +251,9 @@ module.exports = (Block, mcData) => {
           section.write(smartBuffer)
         }
       })
+      if (!smartBuffer.length) {
+        return Buffer.alloc(4096)
+      }
       return smartBuffer.toBuffer()
     }
 

--- a/src/pc/1.17/ChunkColumn.js
+++ b/src/pc/1.17/ChunkColumn.js
@@ -252,7 +252,7 @@ module.exports = (Block, mcData) => {
         }
       })
       if (!smartBuffer.length) {
-        return Buffer.alloc(4096)
+        return Buffer.alloc(1024)
       }
       return smartBuffer.toBuffer()
     }

--- a/src/pc/1.18/ChunkColumn.js
+++ b/src/pc/1.18/ChunkColumn.js
@@ -234,7 +234,7 @@ module.exports = (Block, mcData) => {
         this.biomes[i].write(smartBuffer)
       }
       if (!smartBuffer.length) {
-        return Buffer.alloc(4096)
+        return Buffer.alloc(1024)
       }
       return smartBuffer.toBuffer()
     }

--- a/src/pc/1.18/ChunkColumn.js
+++ b/src/pc/1.18/ChunkColumn.js
@@ -233,6 +233,9 @@ module.exports = (Block, mcData) => {
         this.sections[i].write(smartBuffer)
         this.biomes[i].write(smartBuffer)
       }
+      if (!smartBuffer.length) {
+        return Buffer.alloc(4096)
+      }
       return smartBuffer.toBuffer()
     }
 

--- a/src/pc/1.9/ChunkColumn.js
+++ b/src/pc/1.9/ChunkColumn.js
@@ -183,6 +183,10 @@ module.exports = (Block, mcData) => {
         smartBuffer.writeUInt8(biome)
       })
 
+      if (!smartBuffer.length) {
+        return Buffer.alloc(4096)
+      }
+
       return smartBuffer.toBuffer()
     }
 

--- a/src/pc/1.9/ChunkColumn.js
+++ b/src/pc/1.9/ChunkColumn.js
@@ -184,7 +184,7 @@ module.exports = (Block, mcData) => {
       })
 
       if (!smartBuffer.length) {
-        return Buffer.alloc(4096)
+        return Buffer.alloc(1024)
       }
 
       return smartBuffer.toBuffer()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,7 +34,7 @@ declare class PCChunk extends CommonChunk {
   getBlockData(pos: Vec3): number
   getBlockLight(pos: Vec3): number
   getSkyLight(pos: Vec3): number
-  getBiome(pos: Vec3): number  
+  getBiome(pos: Vec3): number
   setBlockStateId(pos: Vec3, stateId: number): number
   setBlockType(pos: Vec3, id: number): void
   setBlockData(pos: Vec3, data: Buffer): void
@@ -46,7 +46,7 @@ declare class PCChunk extends CommonChunk {
   dumpBiomes(): Array<number>
   dumpLight(): Buffer
   loadLight(data: Buffer, skyLightMask: number, blockLightMask: number, emptySkyLightMask?: number, emptyBlockLightMask?: number): void
-  loadParsedLights(skyLight: Buffer[], blockLight: Buffer[], skyLightMask: number[][], blockLightMask: number[][], emptySkyLightMask: number[][], emptyBlockLightMask: number[][]): void
+  loadParsedLights?(skyLight: Buffer[], blockLight: Buffer[], skyLightMask: number[][], blockLightMask: number[][], emptySkyLightMask: number[][], emptyBlockLightMask: number[][]): void
   loadBiomes(newBiomesArray: Array<number>): void;
   dump(bitMap?: number, skyLightSent?: boolean): Buffer
   load(data: Buffer, bitMap?: number, skyLightSent?: boolean, fullChunk?: boolean): void
@@ -113,7 +113,7 @@ declare class BedrockChunk extends CommonChunk {
   maxCY: number
   // The version of the chunk column (analog to DataVersion on PCChunk)
   chunkVersion: number
-  // Holds all the block entities in the chunk, the string keys are 
+  // Holds all the block entities in the chunk, the string keys are
   // the concatenated chunk column-relative position of the block.
   blockEntities: Record<string, NBT>
   // Holds entities in the chunk, the string key is the entity ID
@@ -174,7 +174,7 @@ declare class BedrockChunk extends CommonChunk {
   networkEncodeSubChunkNoCache(y: number): Promise<Buffer>
 
   /**
-   * 
+   *
    * @param blobs The blob hashes sent in the SubChunk packet
    * @param blobStore The Blob Store holding the chunk data
    * @param payload The remaining data sent in the SubChunk packet, border blocks
@@ -198,7 +198,7 @@ declare class BedrockChunk extends CommonChunk {
   loadHeights(map: Uint16Array): void
   writeHeightMap(stream): void
 
-  // 
+  //
   // Section management
   getSection(pos): SubChunk
   // Returns chunk at a Y index, adjusted for chunks at negative-Y

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,7 +46,7 @@ declare class PCChunk extends CommonChunk {
   dumpBiomes(): Array<number>
   dumpLight(): Buffer
   loadLight(data: Buffer, skyLightMask: number, blockLightMask: number, emptySkyLightMask?: number, emptyBlockLightMask?: number): void
-  loadParsedLights?(skyLight: Buffer[], blockLight: Buffer[], skyLightMask: number[][], blockLightMask: number[][], emptySkyLightMask: number[][], emptyBlockLightMask: number[][]): void
+  loadParsedLight?(skyLight: Buffer[], blockLight: Buffer[], skyLightMask: number[][], blockLightMask: number[][], emptySkyLightMask: number[][], emptyBlockLightMask: number[][]): void
   loadBiomes(newBiomesArray: Array<number>): void;
   dump(bitMap?: number, skyLightSent?: boolean): Buffer
   load(data: Buffer, bitMap?: number, skyLightSent?: boolean, fullChunk?: boolean): void

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,7 +46,7 @@ declare class PCChunk extends CommonChunk {
   dumpBiomes(): Array<number>
   dumpLight(): Buffer
   loadLight(data: Buffer, skyLightMask: number, blockLightMask: number, emptySkyLightMask?: number, emptyBlockLightMask?: number): void
-  loadLightParse(skyLight: Buffer[], blockLight: Buffer[], skyLightMask: number[][], blockLightMask: number[][], emptySkyLightMask: number[][], emptyBlockLightMask: number[][]): void
+  loadParsedLights(skyLight: Buffer[], blockLight: Buffer[], skyLightMask: number[][], blockLightMask: number[][], emptySkyLightMask: number[][], emptyBlockLightMask: number[][]): void
   loadBiomes(newBiomesArray: Array<number>): void;
   dump(bitMap?: number, skyLightSent?: boolean): Buffer
   load(data: Buffer, bitMap?: number, skyLightSent?: boolean, fullChunk?: boolean): void


### PR DESCRIPTION
I already made this test in prismarine-anvil-provider:

```js
const dumped = oldChunk.dump()
const lights = oldChunk.dumpLight()
const biomes = oldChunk.dumpBiomes()

const chunk = new Chunk()
chunk.load(dumped, chunk.getMask(), true, true) // always expects buffer data to read
chunk.loadBiomes(biomes)
chunk.loadParsedLight?.(lights.skyLight, lights.blockLight, chunk.skyLightMask, chunk.blockLightMask, chunk.emptySkyLightMask, chunk.emptyBlockLightMask)
```

which runs against this file: https://github.com/zardoy/prismarine-provider-anvil/blob/everything/test/fixtures/1.13.2/r.-1.-1.mca which appears to be the world of type the void

and checked that native server always sends the buffer filled with 0 in these cases