### PR TITLE
pc1.18+: Fix world height defaults and light masks

### DIFF
--- a/src/pc/1.18/ChunkColumn.js
+++ b/src/pc/1.18/ChunkColumn.js
@@ -297,7 +297,7 @@ module.exports = (Block, mcData) => {
 
     _loadSkyLightNibbles (y, buffer) {
       if (buffer.length !== 2048) throw new Error('Invalid light nibble buffer length: ' + buffer.length)
-     const minCY = Math.abs(this.minY >> 4)
+      const minCY = Math.abs(this.minY >> 4)
       this.skyLightMask.set(y + minCY, 1) // minCY + 1 extra layer below
       this.skyLightSections[y + minCY] = new BitArray({
         bitsPerValue: 4,

--- a/src/pc/1.18/ChunkColumn.js
+++ b/src/pc/1.18/ChunkColumn.js
@@ -6,14 +6,17 @@ const CommonChunkColumn = require('../common/CommonChunkColumn')
 const constants = require('../common/constants')
 const neededBits = require('../common/neededBits')
 
+const AQUATIC_UPDATE_MIN_Y = -64
+const AQUATIC_UPDATE_WORLD_HEIGHT = 384
+
 // wrap with func to provide version specific Block
 module.exports = (Block, mcData) => {
   return class ChunkColumn extends CommonChunkColumn {
     static get section () { return ChunkSection }
     constructor (options) {
       super(mcData)
-      this.minY = options?.minY ?? 0
-      this.worldHeight = options?.worldHeight ?? constants.CHUNK_HEIGHT
+      this.minY = options?.minY ?? AQUATIC_UPDATE_MIN_Y
+      this.worldHeight = options?.worldHeight ?? AQUATIC_UPDATE_WORLD_HEIGHT
       this.numSections = this.worldHeight >> 4
       this.maxBitsPerBlock = neededBits(Object.values(mcData.blocks).reduce((high, block) => Math.max(high, block.maxStateId), 0))
       this.maxBitsPerBiome = neededBits(Object.values(mcData.biomes).length)
@@ -283,9 +286,9 @@ module.exports = (Block, mcData) => {
 
     _loadBlockLightNibbles (y, buffer) {
       if (buffer.length !== 2048) throw new Error('Invalid light nibble buffer length ' + buffer.length)
-      const minCY = this.minY >> 4
-      this.blockLightMask.set(y + minCY + 1, 1) // minCY + 1 extra layer below
-      this.blockLightSections[y - (this.minY >> 4) + 1] = new BitArray({
+      const minCY = Math.abs(this.minY >> 4)
+      this.blockLightMask.set(y + minCY, 1) // minCY + 1 extra layer below
+      this.blockLightSections[y + minCY] = new BitArray({
         bitsPerValue: 4,
         capacity: 4096,
         data: new Int8Array(buffer).buffer
@@ -294,9 +297,9 @@ module.exports = (Block, mcData) => {
 
     _loadSkyLightNibbles (y, buffer) {
       if (buffer.length !== 2048) throw new Error('Invalid light nibble buffer length: ' + buffer.length)
-      const minCY = this.minY >> 4
-      this.skyLightMask.set(y + minCY + 1, 1) // minCY + 1 extra layer below
-      this.skyLightSections[y - minCY + 1] = new BitArray({
+     const minCY = Math.abs(this.minY >> 4)
+      this.skyLightMask.set(y + minCY, 1) // minCY + 1 extra layer below
+      this.skyLightSections[y + minCY] = new BitArray({
         bitsPerValue: 4,
         capacity: 4096,
         data: new Int8Array(buffer).buffer

--- a/src/pc/1.18/ChunkColumn.js
+++ b/src/pc/1.18/ChunkColumn.js
@@ -96,7 +96,8 @@ module.exports = (Block, mcData) => {
 
     initialize (func) {
       const p = { x: 0, y: 0, z: 0 }
-      for (p.y = 0; p.y < this.worldHeight; p.y++) {
+      const maxY = this.worldHeight + this.minY
+      for (p.y = this.minY; p.y < maxY; p.y++) {
         for (p.z = 0; p.z < constants.SECTION_WIDTH; p.z++) {
           for (p.x = 0; p.x < constants.SECTION_WIDTH; p.x++) {
             const block = func(p.x, p.y, p.z)


### PR DESCRIPTION
The world height changed in 1.18+ to be between -64 and +320. The value set to the ChunkColumn have to be aligned with the dimension codec or the game will sometimes crash the game and otherwise cause chunks to be misplaced, eg:

![image](https://github.com/user-attachments/assets/b88d78db-094f-4b99-8cad-0ad687e08f35)

Since we don't have a way to store this data inside prismarine-registry yet I just fix by changing the defaults to be correct 1.18 defaults

Also fix for light masks