### PR TITLE
Fix pc1.18 light index

### DIFF
--- a/src/pc/1.18/ChunkColumn.js
+++ b/src/pc/1.18/ChunkColumn.js
@@ -6,8 +6,8 @@ const CommonChunkColumn = require('../common/CommonChunkColumn')
 const constants = require('../common/constants')
 const neededBits = require('../common/neededBits')
 
-const AQUATIC_UPDATE_MIN_Y = -64
-const AQUATIC_UPDATE_WORLD_HEIGHT = 384
+const CAVES_UPDATE_MIN_Y = -64
+const CAVES_UPDATE_WORLD_HEIGHT = 384
 
 // wrap with func to provide version specific Block
 module.exports = (Block, mcData) => {
@@ -15,8 +15,8 @@ module.exports = (Block, mcData) => {
     static get section () { return ChunkSection }
     constructor (options) {
       super(mcData)
-      this.minY = options?.minY ?? AQUATIC_UPDATE_MIN_Y
-      this.worldHeight = options?.worldHeight ?? AQUATIC_UPDATE_WORLD_HEIGHT
+      this.minY = options?.minY ?? CAVES_UPDATE_MIN_Y
+      this.worldHeight = options?.worldHeight ?? CAVES_UPDATE_WORLD_HEIGHT
       this.numSections = this.worldHeight >> 4
       this.maxBitsPerBlock = neededBits(Object.values(mcData.blocks).reduce((high, block) => Math.max(high, block.maxStateId), 0))
       this.maxBitsPerBiome = neededBits(Object.values(mcData.biomes).length)
@@ -287,8 +287,8 @@ module.exports = (Block, mcData) => {
 
     _loadBlockLightNibbles (y, buffer) {
       if (buffer.length !== 2048) throw new Error('Invalid light nibble buffer length ' + buffer.length)
-      const minCY = Math.abs(this.minY >> 4)
-      this.blockLightMask.set(y + minCY, 1) // minCY + 1 extra layer below
+      const minCY = Math.abs(this.minY >> 4) + 1 // minCY + 1 extra layer below
+      this.blockLightMask.set(y + minCY, 1)
       this.blockLightSections[y + minCY] = new BitArray({
         bitsPerValue: 4,
         capacity: 4096,
@@ -298,8 +298,8 @@ module.exports = (Block, mcData) => {
 
     _loadSkyLightNibbles (y, buffer) {
       if (buffer.length !== 2048) throw new Error('Invalid light nibble buffer length: ' + buffer.length)
-      const minCY = Math.abs(this.minY >> 4)
-      this.skyLightMask.set(y + minCY, 1) // minCY + 1 extra layer below
+      const minCY = Math.abs(this.minY >> 4) + 1 // minCY + 1 extra layer below
+      this.skyLightMask.set(y + minCY, 1)
       this.skyLightSections[y + minCY] = new BitArray({
         bitsPerValue: 4,
         capacity: 4096,


### PR DESCRIPTION
Fix https://github.com/PrismarineJS/prismarine-chunk/pull/267 removing the +1 offset for light