### PR TITLE
Fix setBiome() fails below Y = 0 (missing minY offset)

### DIFF
--- a/src/pc/1.18/ChunkColumn.js
+++ b/src/pc/1.18/ChunkColumn.js
@@ -224,7 +224,7 @@ module.exports = (Block, mcData) => {
 
     setBiome (pos, biomeId) {
       const biome = this.biomes[(pos.y - this.minY) >> 4]
-      if (biome) { biome.set(toBiomePos(pos), biomeId) }
+      if (biome) { biome.set(toBiomePos(pos, this.minY), biomeId) }
     }
 
     getMask () {


### PR DESCRIPTION
**[Summary]**
With 1.18+ worlds that start at minY = -64, ```ChunkColumn#setBiome()``` fails to write biomes below Y=0.

**[Root cause]**
```minY``` is not passed to ```toBiomePos()```, so the Y offset is lost and the biome index is mis-computed.

```
// prismarine-chunk/src/pc/1.18/ChunkColumn.js
setBiome (pos, biomeId) {
  const biome = this.biomes[(pos.y - this.minY) >> 4]
- if (biome) { biome.set(toBiomePos(pos), biomeId) }
+ if (biome) { biome.set(toBiomePos(pos, this.minY), biomeId) }
}
```

**[Steps to reproduce]**
```
const Chunk = require('prismarine-chunk')('1.18')  // up to 1.20.x
const chunk = new Chunk({ minY: -64, worldHeight: 384 })
const plains = 1 // biome id
chunk.setBiome({ x: 0, y: -10, z: 0 }, plains)
console.log(chunk.getBiome({ x: 0, y: -10, z: 0 })) // expected 1, actual 0
```

**[Expected behavior]**
```setBiome()``` followed by ```getBiome()``` should return the same biome for any Y between -64 and 319.

**[Environment]**
prismarine-chunk | 1.7.0 (HEAD)
Node.js | 16.17.0
OS | macOS Sequoia

**[Notes]**

- Read path is already correct (getBiome() passes this.minY), so the fix is safe and self-contained.
- A regression test covering Y = -64, -1, 0, 319 is recommended.

**[Sample]**
Example of executing ```chunk.setBiome(vec3,plainID)```
Even though plain ID=1 is specified in the before, biomeID is 0 at the grass_block position on this screen (Y=-1), but in the after, biome can be set at negative Y coordinates and is normally the color of the plain grass block.

**[Before]**
<img width="1121" alt="スクリーンショット 2025-05-22 11 19 22" src="https://github.com/user-attachments/assets/8c20f49a-cdf4-4b80-af96-53ff03d67ae5" />

**[After]**
![スクリーンショット 2025-05-15 21 01 32](https://github.com/user-attachments/assets/f887db48-0f85-451f-a0f1-4c23c98bfe6c)


Thanks!

