### PR TITLE
Add 26.1 chunk section compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ const chunkImplementations = {
     1.18: require('./pc/1.18/chunk'),
     1.19: require('./pc/1.18/chunk'),
     '1.20': require('./pc/1.18/chunk'),
-    1.21: require('./pc/1.18/chunk')
+    1.21: require('./pc/1.18/chunk'),
+    26.1: require('./pc/1.18/chunk')
   },
   bedrock: {
     0.14: require('./bedrock/0.14/chunk'),

--- a/src/pc/1.18/ChunkColumn.js
+++ b/src/pc/1.18/ChunkColumn.js
@@ -13,6 +13,7 @@ const CAVES_UPDATE_WORLD_HEIGHT = 384
 module.exports = (Block, mcData) => {
   // 1.21.5+ writes no size prefix before chunk containers, it's computed dynamically to save 1 byte
   const noSizePrefix = mcData.version['>=']('1.21.5')
+  const usesFluidCount = String(mcData.version.majorVersion) === '26.1'
   return class ChunkColumn extends CommonChunkColumn {
     static get section () { return ChunkSection }
     constructor (options) {
@@ -24,7 +25,7 @@ module.exports = (Block, mcData) => {
       this.maxBitsPerBiome = neededBits(Object.values(mcData.biomes).length)
 
       this.sections = options?.sections ?? Array.from(
-        { length: this.numSections }, _ => new ChunkSection({ noSizePrefix, maxBitsPerBlock: this.maxBitsPerBlock })
+        { length: this.numSections }, _ => new ChunkSection({ noSizePrefix, maxBitsPerBlock: this.maxBitsPerBlock, usesFluidCount })
       )
       this.biomes = options?.biomes ?? Array.from(
         { length: this.numSections }, _ => new BiomeSection({ noSizePrefix })
@@ -252,7 +253,7 @@ module.exports = (Block, mcData) => {
     load (data) {
       const reader = SmartBuffer.fromBuffer(data)
       for (let i = 0; i < this.numSections; ++i) {
-        this.sections[i] = ChunkSection.read(reader, this.maxBitsPerBlock, noSizePrefix)
+        this.sections[i] = ChunkSection.read(reader, this.maxBitsPerBlock, noSizePrefix, usesFluidCount)
         this.biomes[i] = BiomeSection.read(reader, this.maxBitsPerBiome, noSizePrefix)
       }
     }
@@ -316,6 +317,7 @@ module.exports = (Block, mcData) => {
       // TOOD: we should probably not fail, but because we use numerical biome IDs in pchunk we need to fail
       const raiseUnknownBiome = biome => { throw new Error(`Failed to map ${JSON.stringify(biome)} to a biome ID`) }
       this.sections[y + minCY] = ChunkSection.fromLocalPalette({
+        usesFluidCount,
         noSizePrefix,
         data: BitArray.fromLongArray(blockStates.data || {}, blockStates.bitsPerBlock),
         palette: blockStates.palette

--- a/src/pc/common/PaletteChunkSection.js
+++ b/src/pc/common/PaletteChunkSection.js
@@ -12,6 +12,7 @@ function getBlockIndex (pos) {
 class ChunkSection {
   constructor (options) {
     this.noSizePrefix = options?.noSizePrefix // 1.21.5+ writes no size prefix before chunk containers, it's computed dynamically to save 1 byte
+    this.usesFluidCount = options?.usesFluidCount ?? false
     this.data = options?.data
     if (!this.data) {
       const value = options?.singleValue ?? 0
@@ -32,21 +33,29 @@ class ChunkSection {
         }
       }
     }
+    this.fluidCount = options?.fluidCount ?? 0
     this.palette = this.data.palette
   }
 
   toJson () {
-    return JSON.stringify({
+    const payload = {
       data: this.data.toJson(),
       solidBlockCount: this.solidBlockCount
-    })
+    }
+    if (this.usesFluidCount) {
+      payload.usesFluidCount = true
+      payload.fluidCount = this.fluidCount
+    }
+    return JSON.stringify(payload)
   }
 
   static fromJson (j) {
     const parsed = JSON.parse(j)
     return new ChunkSection({
+      usesFluidCount: parsed.usesFluidCount ?? false,
       data: paletteContainer.fromJson(parsed.data),
-      solidBlockCount: parsed.solidBlockCount
+      solidBlockCount: parsed.solidBlockCount,
+      fluidCount: parsed.fluidCount ?? 0
     })
   }
 
@@ -74,11 +83,15 @@ class ChunkSection {
 
   write (smartBuffer) {
     smartBuffer.writeInt16BE(this.solidBlockCount)
+    if (this.usesFluidCount) {
+      smartBuffer.writeInt16BE(this.fluidCount)
+    }
     this.data.write(smartBuffer)
   }
 
-  static fromLocalPalette ({ data, palette, noSizePrefix }) {
+  static fromLocalPalette ({ data, palette, noSizePrefix, usesFluidCount }) {
     return new ChunkSection({
+      usesFluidCount,
       noSizePrefix,
       data: palette.length === 1
         ? new SingleValueContainer({
@@ -96,15 +109,18 @@ class ChunkSection {
     })
   }
 
-  static read (smartBuffer, maxBitsPerBlock = constants.GLOBAL_BITS_PER_BLOCK, noSizePrefix) {
+  static read (smartBuffer, maxBitsPerBlock = constants.GLOBAL_BITS_PER_BLOCK, noSizePrefix, usesFluidCount = false) {
     const solidBlockCount = smartBuffer.readInt16BE()
+    const fluidCount = usesFluidCount ? smartBuffer.readInt16BE() : 0
     const bitsPerBlock = smartBuffer.readUInt8()
     if (bitsPerBlock > 16) throw new Error(`Bits per block is too big: ${bitsPerBlock}`)
     // Case 1: Single Value Container (all blocks in the section are the same)
     if (bitsPerBlock === 0) {
       const section = new ChunkSection({
+        usesFluidCount,
         noSizePrefix,
         solidBlockCount,
+        fluidCount,
         singleValue: varInt.read(smartBuffer),
         maxBitsPerBlock
       })
@@ -115,8 +131,10 @@ class ChunkSection {
     // Case 2: Direct Palette (global palette)
     if (bitsPerBlock > constants.MAX_BITS_PER_BLOCK) {
       return new ChunkSection({
+        usesFluidCount,
         noSizePrefix,
         solidBlockCount,
+        fluidCount,
         data: new DirectPaletteContainer({
           noSizePrefix,
           bitsPerValue: maxBitsPerBlock,
@@ -133,8 +151,10 @@ class ChunkSection {
     }
 
     return new ChunkSection({
+      usesFluidCount,
       noSizePrefix,
       solidBlockCount,
+      fluidCount,
       data: new IndirectPaletteContainer({
         noSizePrefix,
         bitsPerValue: bitsPerBlock,


### PR DESCRIPTION
## Summary
This updates prismarine-chunk for 26.1.

## What changed
- adds `26.1` to the supported PC chunk implementation list
- updates `PaletteChunkSection` to handle the extra `fluidCount` field used by 26.1
- keeps the older shared 1.18+ path unchanged for versions that do not use that field

## Why
26.1 chunk sections include an extra `fluidCount` value.

Without that, section data is read with the wrong layout, which can throw off later block decoding.