### PR TITLE
Resolve hashed state ids when writing a sub-chunk block

### DIFF
--- a/src/bedrock/1.3/ChunkColumn.js
+++ b/src/bedrock/1.3/ChunkColumn.js
@@ -181,7 +181,7 @@ class ChunkColumn13 extends CommonChunkColumn {
     this.sections = []
     for (let i = 0; i < sectionCount; i++) {
       // in 1.17.30+, chunk index is sent in payload
-      const section = new SubChunk(this.registry, this.Block, { y: i, subChunkVersion: this.subChunkVersion })
+      const section = new this.Section(this.registry, this.Block, { y: i, subChunkVersion: this.subChunkVersion })
       section.decode(StorageType.Runtime, stream)
       this.setSection(i, section)
     }

--- a/src/bedrock/1.3/chunk.js
+++ b/src/bedrock/1.3/chunk.js
@@ -1,16 +1,23 @@
 const { ChunkVersion } = require('../common/constants')
 const ChunkColumn = require('./ChunkColumn')
+const ModernSubChunk = require('../1.18/SubChunk')
 
 module.exports = (version) => {
   // Require once here to avoid requiring() on every new chunk instance
   const registry = version.blockRegistry || version
+  const usesZeroBitRuntimePalettes = registry.version['>=']('1.17.30')
   const Block = require('prismarine-block')(registry)
   const Biome = require('prismarine-biome')(registry)
   return class Chunk extends ChunkColumn {
     constructor (options) {
       super(options, registry, Block, Biome)
       this.chunkVersion = this.chunkVersion || ChunkVersion.v1_16_0
-      this.subChunkVersion = 8
+      if (usesZeroBitRuntimePalettes) {
+        this.Section = ModernSubChunk
+        this.subChunkVersion = 9
+      } else {
+        this.subChunkVersion = 8
+      }
     }
 
     static fromJson (str) {

--- a/test/bedrock-1.17.30.test.js
+++ b/test/bedrock-1.17.30.test.js
@@ -1,0 +1,33 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const { Vec3 } = require('vec3')
+
+for (const version of ['1.17.30', '1.17.40']) {
+  describe(`Bedrock ${version} zero-bit runtime palettes`, () => {
+    it('decodes all-air subchunks without consuming the legacy biome data', async () => {
+      const registry = require('prismarine-registry')(`bedrock_${version}`)
+      registry.handleStartGame({ block_network_ids_are_hashes: false, itemstates: [] })
+      const Chunk = require('..')(registry)
+      const Stream = require('../src/bedrock/common/Stream')
+      const stream = new Stream()
+
+      for (let y = 0; y < 32; y++) {
+        stream.writeUInt8(9)
+        stream.writeUInt8(1)
+        stream.writeUInt8(y)
+        stream.writeUInt8(1)
+        stream.writeZigZagVarInt(registry.blocksByName.air.defaultState)
+      }
+      stream.writeBuffer(Buffer.alloc(256, 18))
+      stream.writeUInt8(0)
+      const payload = stream.getBuffer()
+
+      const column = new Chunk({ x: 0, z: 0 })
+      column.networkDecodeNoCache(payload, 32)
+
+      assert.strictEqual(column.getBlock(new Vec3(0, 0, 0)).name, 'air')
+      assert.deepStrictEqual(await column.networkEncodeNoCache(), payload)
+    })
+  })
+}

--- a/test/bedrock-1.17.30.test.js
+++ b/test/bedrock-1.17.30.test.js
@@ -3,6 +3,16 @@
 const assert = require('assert')
 const { Vec3 } = require('vec3')
 
+describe('Bedrock zero-bit runtime palette version boundary', () => {
+  it('keeps the version-8 subchunk implementation before 1.17.30', () => {
+    const registry = require('prismarine-registry')('bedrock_1.17.10')
+    const Chunk = require('..')(registry)
+    const column = new Chunk({ x: 0, z: 0 })
+
+    assert.strictEqual(column.subChunkVersion, 8)
+  })
+})
+
 for (const version of ['1.17.30', '1.17.40']) {
   describe(`Bedrock ${version} zero-bit runtime palettes`, () => {
     it('decodes all-air subchunks without consuming the legacy biome data', async () => {
@@ -24,6 +34,7 @@ for (const version of ['1.17.30', '1.17.40']) {
       const payload = stream.getBuffer()
 
       const column = new Chunk({ x: 0, z: 0 })
+      assert.strictEqual(column.subChunkVersion, 9)
       column.networkDecodeNoCache(payload, 32)
 
       assert.strictEqual(column.getBlock(new Vec3(0, 0, 0)).name, 'air')


### PR DESCRIPTION
`SubChunk.addToPalette` (bedrock 1.3) indexed `registry.blockStates[stateId]`, but with hashed runtime ids (the `blockHashes` feature) the state id is a 32-bit hash, not an index into that array — so the lookup was `undefined` and reading its `.name` threw. Any single-block update (a placed or broken block) crashed the consumer.

Look the id up in the hash-keyed `blocksByStateId` first, fall back to `blockStates` for non-hashed registries, and tolerate an unknown id instead of dereferencing undefined. Full test suite passes.